### PR TITLE
Make model & model contract compatible with php < 7.4

### DIFF
--- a/src/Models/Contracts/Model.php
+++ b/src/Models/Contracts/Model.php
@@ -19,11 +19,11 @@ interface Model {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array $attributes
+	 * @param array<string,mixed> $attributes Attributes.
 	 *
-	 * @return self
+	 * @return Model
 	 */
-	public function fill( array $attributes ) : self;
+	public function fill( array $attributes ) : Model;
 
 	/**
 	 * Get an attribute from the model.
@@ -115,18 +115,21 @@ interface Model {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return $this
+	 * @param string $key   Attribute name.
+	 * @param mixed  $value Attribute value.
+	 *
+	 * @return Model
 	 */
-	public function setAttribute( string $key, $value ) : self;
+	public function setAttribute( string $key, $value ) : Model;
 
 	/**
 	 * Sync the original attributes with the current.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return $this
+	 * @return Model
 	 */
-	public function syncOriginal() : self;
+	public function syncOriginal() : Model;
 
 	/**
 	 * Dynamically retrieve attributes on the model.

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -64,9 +64,9 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @param array $attributes
 	 *
-	 * @return Model
+	 * @return ModelInterface
 	 */
-	public function fill( array $attributes ) : Model {
+	public function fill( array $attributes ) : ModelInterface {
 		foreach ( $attributes as $key => $value ) {
 			$this->setAttribute( $key, $value );
 		}
@@ -304,9 +304,12 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return $this
+	 * @param string $key   Attribute name.
+	 * @param mixed  $value Attribute value.
+	 *
+	 * @return ModelInterface
 	 */
-	public function setAttribute( string $key, $value ) : Model {
+	public function setAttribute( string $key, $value ) : ModelInterface {
 		$this->validatePropertyExists( $key );
 		$this->validatePropertyType( $key, $value );
 
@@ -320,9 +323,9 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return $this
+	 * @return ModelInterface
 	 */
-	public function syncOriginal() : Model {
+	public function syncOriginal() : ModelInterface {
 		$this->original = $this->attributes;
 
 		return $this;


### PR DESCRIPTION
The `self` return type before PHP 7.4 is not that smart.