### PR TITLE
Support a custom default value in the getAttribute method

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -80,14 +80,17 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param string $key     Attribute name.
+	 * @param mixed  $default Default value. Default is null.
+	 *
 	 * @return mixed
 	 *
 	 * @throws RuntimeException
 	 */
-	public function getAttribute( string $key ) {
+	public function getAttribute( string $key, $default = null ) {
 		$this->validatePropertyExists( $key );
 
-		return $this->attributes[ $key ] ?? null;
+		return $this->attributes[ $key ] ?? $default;
 	}
 
 	/**

--- a/tests/wpunit/ModelTest.php
+++ b/tests/wpunit/ModelTest.php
@@ -66,6 +66,20 @@ class TestModel extends ModelsTestCase {
 	}
 
 	/**
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function testGetAttributeShouldReturnCustomDefaultValue() {
+		$model = new MockModel( [ 'id' => 1 ] );
+
+		$this->assertEquals(
+			'shakalaka',
+			$model->getAttribute( 'lastName', 'shakalaka' )
+		);
+	}
+
+	/**
 	 * @since 2.20.1
 	 *
 	 * @return void


### PR DESCRIPTION
We have a similar helper in LD, so it might be useful here (not sure though).

It allows to set a custom default value optionally.

Before:

`$model->getAttribute( 'lastName' ); // null`

After:

`$model->getAttribute( 'lastName', 'shakalaka' ); // shakalaka`