### PR TITLE
Fix jsonSerialize() PHP 8.1 compatibility

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -3,7 +3,6 @@
 namespace StellarWP\Models;
 
 use JsonSerializable;
-use ReturnTypeWillChange;
 use RuntimeException;
 use StellarWP\Models\Contracts\Arrayable;
 use StellarWP\Models\Contracts\Model as ModelInterface;
@@ -299,7 +298,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @return array<string,mixed>
 	 */
-	#[ReturnTypeWillChange]
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return get_object_vars( $this );
 	}

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -3,6 +3,7 @@
 namespace StellarWP\Models;
 
 use JsonSerializable;
+use ReturnTypeWillChange;
 use RuntimeException;
 use StellarWP\Models\Contracts\Arrayable;
 use StellarWP\Models\Contracts\Model as ModelInterface;
@@ -298,6 +299,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @return array<string,mixed>
 	 */
+	#[ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return get_object_vars( $this );
 	}


### PR DESCRIPTION
PHP: 8.1

`PHP Deprecated:  Return type of StellarWP\Learndash\StellarWP\Models\Model::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/vendor-prefixed/stellarwp/models/src/Models/Model.php on line 320`