### PR TITLE
Bug fix for fetching set of defaults, don't always add a null.

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -125,6 +125,19 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	}
 
 	/**
+	 * Check if there is a default value for a property.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key Property name.
+	 *
+	 * @return bool
+	 */
+	public function hasDefault( string $key ): bool {
+		return is_array( $this->properties[ $key ] ) && array_key_exists( 1, $this->properties[ $key ] );
+	}
+
+	/**
 	 * Returns the default value for a property if one is provided, otherwise null.
 	 *
 	 * @since 1.0.0
@@ -134,9 +147,11 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 * @return mixed|null
 	 */
 	protected function getPropertyDefault( string $key ) {
-		return is_array( $this->properties[ $key ] ) && isset( $this->properties[ $key ][1] )
-			? $this->properties[ $key ][1]
-			: null;
+		if ( $this->hasDefault( $key ) ) {
+			return $this->properties[ $key ][1];
+		}
+
+		return null;
 	}
 
 	/**
@@ -149,7 +164,9 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	protected function getPropertyDefaults() : array {
 		$defaults = [];
 		foreach ( array_keys( $this->properties ) as $property ) {
-			$defaults[ $property ] = $this->getPropertyDefault( $property );
+			if ( $this->hasDefault( $property ) ) {
+				$defaults[ $property ] = $this->getPropertyDefault( $property );
+			}
 		}
 
 		return $defaults;

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -128,7 +128,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 * Whether the property is set or not. This is different from isset() because this considers a `null` value as
 	 * being set. Defaults are considered set as well.
 	 *
-	 * @since TBD
+	 * @unreleased
 	 *
 	 * @return boolean
 	 */
@@ -139,7 +139,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Check if there is a default value for a property.
 	 *
-	 * @since TBD
+	 * @unreleased
 	 *
 	 * @param string $key Property name.
 	 *

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -125,6 +125,18 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	}
 
 	/**
+	 * Whether the property is set or not. This is different from isset() because this considers a `null` value as
+	 * being set. Defaults are considered set as well.
+	 *
+	 * @since TBD
+	 *
+	 * @return boolean
+	 */
+	public function isSet( string $key ): bool {
+		return array_key_exists( $key, $this->attributes ) || $this->hasDefault( $key );
+	}
+
+	/**
 	 * Check if there is a default value for a property.
 	 *
 	 * @since TBD
@@ -133,7 +145,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @return bool
 	 */
-	public function hasDefault( string $key ): bool {
+	protected function hasDefault( string $key ): bool {
 		return is_array( $this->properties[ $key ] ) && array_key_exists( 1, $this->properties[ $key ] );
 	}
 

--- a/tests/wpunit/ModelTest.php
+++ b/tests/wpunit/ModelTest.php
@@ -282,11 +282,18 @@ class TestModel extends ModelsTestCase {
 	 *
 	 * @return void
 	 */
-	public function testHasDefaultValue() {
+	public function testIsSet() {
 		$model = new MockModel();
-		$this->assertTrue( $model->hasDefault( 'firstName' ) );
-		$this->assertTrue( $model->hasDefault( 'emails' ) );
-		$this->assertFalse( $model->hasDefault( 'lastName' ) );
+
+		// This has a default so we should see as set.
+		$this->assertTrue( $model->isSet( 'firstName' ) );
+
+		// No default, and hasn't been set so show false.
+		$this->assertFalse( $model->isSet( 'lastName' ) );
+
+		// Now we set it, so it should be true - even though we set it to null.
+		$model->lastName = null;
+		$this->assertTrue( $model->isSet( 'lastName' ) );
 	}
 
 	/**

--- a/tests/wpunit/ModelTest.php
+++ b/tests/wpunit/ModelTest.php
@@ -278,7 +278,7 @@ class TestModel extends ModelsTestCase {
 	}
 
 	/**
-	 * @since TBD
+	 * @unreleased
 	 *
 	 * @return void
 	 */

--- a/tests/wpunit/ModelTest.php
+++ b/tests/wpunit/ModelTest.php
@@ -278,6 +278,18 @@ class TestModel extends ModelsTestCase {
 	}
 
 	/**
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function testHasDefaultValue() {
+		$model = new MockModel();
+		$this->assertTrue( $model->hasDefault( 'firstName' ) );
+		$this->assertTrue( $model->hasDefault( 'emails' ) );
+		$this->assertFalse( $model->hasDefault( 'lastName' ) );
+	}
+
+	/**
 	 * @since 1.0.0
 	 *
 	 * @return array


### PR DESCRIPTION
Avoid a false positive in fetching defaults with a check that validates whether one is truly set or not. This avoids situations where we might force a `null` into a database, instead of allowing the MySQL default to take precedence.