### PR TITLE
Adding float as valid type.

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -328,6 +328,8 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 				return is_bool( $value );
 			case 'array':
 				return is_array( $value );
+			case 'float':
+				return is_float( $value );
 			default:
 				return $value instanceof $type;
 		}

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -330,8 +330,8 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 				return is_array( $value );
 			case 'float':
 				return is_float( $value );
-			case 'numeric':
-				return is_numeric( $value );
+			case 'number':
+				return is_int( $value ) || is_float( $value );
 			default:
 				return $value instanceof $type;
 		}

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -330,6 +330,8 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 				return is_array( $value );
 			case 'float':
 				return is_float( $value );
+			case 'numeric':
+				return is_numeric( $value );
 			default:
 				return $value instanceof $type;
 		}

--- a/tests/_support/Helper/MockModel.php
+++ b/tests/_support/Helper/MockModel.php
@@ -6,9 +6,10 @@ use StellarWP\Models\Model;
 
 class MockModel extends Model {
 	protected $properties = [
-		'id'        => 'int',
-		'firstName' => [ 'string', 'Michael' ],
-		'lastName'  => 'string',
-		'emails'    => [ 'array', [] ],
+		'id'           => 'int',
+		'firstName'    => [ 'string', 'Michael' ],
+		'lastName'     => 'string',
+		'emails'       => [ 'array', [] ],
+		'microseconds' => 'float',
 	];
 }

--- a/tests/_support/Helper/MockModel.php
+++ b/tests/_support/Helper/MockModel.php
@@ -11,6 +11,6 @@ class MockModel extends Model {
 		'lastName'     => 'string',
 		'emails'       => [ 'array', [] ],
 		'microseconds' => 'float',
-		'number'       => 'numeric',
+		'number'       => 'number',
 	];
 }

--- a/tests/_support/Helper/MockModel.php
+++ b/tests/_support/Helper/MockModel.php
@@ -11,5 +11,6 @@ class MockModel extends Model {
 		'lastName'     => 'string',
 		'emails'       => [ 'array', [] ],
 		'microseconds' => 'float',
+		'number'       => 'numeric',
 	];
 }

--- a/tests/wpunit/ModelTest.php
+++ b/tests/wpunit/ModelTest.php
@@ -306,7 +306,8 @@ class TestModel extends ModelsTestCase {
 			[ 'id', 'Not an integer' ],
 			[ 'firstName', 100 ],
 			[ 'emails', 'Not an array' ],
-			[ 'microseconds', 'Not a float' ]
+			[ 'microseconds', 'Not a float' ],
+			[ 'number', 'Not a number' ]
 		];
 	}
 }

--- a/tests/wpunit/ModelTest.php
+++ b/tests/wpunit/ModelTest.php
@@ -307,7 +307,7 @@ class TestModel extends ModelsTestCase {
 			[ 'firstName', 100 ],
 			[ 'emails', 'Not an array' ],
 			[ 'microseconds', 'Not a float' ],
-			[ 'number', 'Not a number' ]
+			[ 'number', '12' ] // numeric strings do not work; must be int or float
 		];
 	}
 }

--- a/tests/wpunit/ModelTest.php
+++ b/tests/wpunit/ModelTest.php
@@ -306,6 +306,7 @@ class TestModel extends ModelsTestCase {
 			[ 'id', 'Not an integer' ],
 			[ 'firstName', 100 ],
 			[ 'emails', 'Not an array' ],
+			[ 'microseconds', 'Not a float' ]
 		];
 	}
 }


### PR DESCRIPTION
Allow the `float` datatype.
```
class MyModel extends Model {
	protected $properties = [
		'total_query_time'   => 'float'
	];
...
```