### PR TITLE
Feature: adds generics support to the ModelQueryBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/strauss.phar
 files/
 repo/
 vendor/
+.idea

--- a/src/Models/ModelQueryBuilder.php
+++ b/src/Models/ModelQueryBuilder.php
@@ -58,7 +58,7 @@ class ModelQueryBuilder extends QueryBuilder {
 	 *
 	 * @return M|null
 	 */
-	public function get( $output = OBJECT ) {
+	public function get( $output = OBJECT ): ?Model {
 		$row = DB::get_row( $this->getSQL(), OBJECT );
 
 		if ( ! $row ) {

--- a/src/Models/ModelQueryBuilder.php
+++ b/src/Models/ModelQueryBuilder.php
@@ -10,15 +10,18 @@ use StellarWP\Models\Model;
 
 /**
  * @since 1.0.0
+ * @unreleased improve model generic
+ *
+ * @template M of Model
  */
 class ModelQueryBuilder extends QueryBuilder {
 	/**
-	 * @var class-string<Model>
+	 * @var class-string<M>
 	 */
 	protected $model;
 
 	/**
-	 * @param class-string<Model> $modelClass
+	 * @param class-string<M> $modelClass
 	 */
 	public function __construct( string $modelClass ) {
 		if ( ! is_subclass_of( $modelClass, Model::class ) ) {
@@ -53,9 +56,9 @@ class ModelQueryBuilder extends QueryBuilder {
 	 *
 	 * @param string $output
 	 *
-	 * @return Model|null
+	 * @return M|null
 	 */
-	public function get( $output = OBJECT ) : ?Model {
+	public function get( $output = OBJECT ) {
 		$row = DB::get_row( $this->getSQL(), OBJECT );
 
 		if ( ! $row ) {
@@ -70,7 +73,7 @@ class ModelQueryBuilder extends QueryBuilder {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return Model[]|null
+	 * @return M[]|null
 	 */
 	public function getAll( $output = OBJECT ) : ?array {
 		$results = DB::get_results( $this->getSQL(), OBJECT );
@@ -93,7 +96,7 @@ class ModelQueryBuilder extends QueryBuilder {
 	 *
 	 * @param object|null $row
 	 *
-	 * @return Model|null
+	 * @return M|null
 	 */
 	protected function getRowAsModel( $row ) {
 		$model = $this->model;
@@ -112,7 +115,7 @@ class ModelQueryBuilder extends QueryBuilder {
 	 *
 	 * @param object[] $results
 	 *
-	 * @return Model[]|null
+	 * @return M[]|null
 	 */
 	protected function getAllAsModel( array $results ) {
 		/** @var Contracts\ModelCrud $model */


### PR DESCRIPTION
The `ModelQueryBuilder` currently assumes that all model instances being returned are the Model class itself. This PR adds support for generics so things like `@return ModelQueryBuilder<MyModel>` are supported. This addresses issues from static analysis.