### PR TITLE
Feature: Add deferred resolution to model factory

### DIFF
--- a/src/Models/ModelFactory.md
+++ b/src/Models/ModelFactory.md
@@ -1,0 +1,114 @@
+# Model Factory
+
+## Introduction
+
+Factory classes are used to programmatically create instances of models. This is useful for seeding databases, creating test data, and other situations where you need to create a lot of model instances.
+
+```php
+<?php
+
+namespace Give\Campaigns\Factories;
+
+class CampaignFactory extends Give\Framework\Models\Factories\ModelFactory
+{
+    public function definition(): array
+    {
+        return [
+            'title' => __('GiveWP Campaign', 'give'),
+            'description' => $this->faker->paragraph(),
+        ];
+    }
+}
+```
+
+Each instance of a model created by a factory class is populated with default values defined in the `definition` method, which can be hard-coded or generated dynamically using integrated the `fakerphp/faker` library.
+
+## Creating Models with Factories
+
+A model can be instantiated using the factory `make()` method, which uses the defaults provided by the `definition()` method to create the model instance.
+
+```php
+use Give\Campaigns\Models\Campaign;
+
+$campaign = Campaign::factory()->make();
+```
+
+Additionally, multiple model instances can be created using the `count()` method.
+
+```php
+use Give\Campaigns\Models\Campaign;
+
+$campaigns = Campaign::factory()->count(3)->make();
+```
+
+### Overriding Attributes
+
+You can override these default values by passing an array of attributes to the factory's `make()` or `create()` method.
+
+```php
+use Give\Campaigns\Models\Campaign;
+
+$campaign Campaign::factory()->create([
+    'title' => 'My Custom Campaign',
+]);
+```
+
+### Persisting Models
+
+The `create()` method instantiates model instances and persists them to the database using model's `save()` method.
+
+```php
+use Give\Campaigns\Models\Campaign;
+
+$campaign Campaign::factory()->create();
+```
+
+### Deferred Resolution
+
+Sometimes you may need to defer the resolution of an attribute until the model is being created. Either the attribute definition is not a simple value or is otherwise expensive to instantiate.
+
+Factory attribute definitions can be deferred using `Closure` callbacks instead of a hard-coded or generated value.
+
+```php
+    public function definition(): array
+    {
+        return [
+            'title' => __('GiveWP Campaign', 'give'),
+            'description' => function() {
+                return prompt('Write a short description for a fundraising campaign.')
+            },
+        ];
+    }
+```
+
+Additionally, deferred attributes are not resolved when the attribute is overridden, which prevents unnecessary computation when the default value is not used.
+
+```php
+$campaign = Campaign::factory()->create([
+    'description' => 'My custom description',
+]);
+```
+
+## Model Relationships with Factories
+
+Attribute definitions can also be other model factories, which can be resolved to a property value, such as an ID, to create required dependencies.
+
+```php
+    public function definition(): array
+    {
+        return [
+            'title' => __('GiveWP Campaign', 'give'),
+            'formId' => DonationForm::factory()->createAndResolveTo('id'),
+        ];
+    }
+```
+
+This is particularly useful when defining model relationships, where the related model is only instantiated when a model is not explicity provided as an override.
+
+If an existing model (or model ID) is provided as an override, the factory will not instantiate an additional model.
+
+```php
+Campaign::factory()->create([
+    'formId' => $donationForm->id,
+]);
+```

--- a/src/Models/ModelFactory.php
+++ b/src/Models/ModelFactory.php
@@ -55,7 +55,7 @@ abstract class ModelFactory {
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function makeAndResolveTo($property): Closure
 	{
@@ -88,13 +88,12 @@ abstract class ModelFactory {
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
-	public function createAndResolveTo($property): Closure
-	{
-		return function() use ($property) {
-			return is_array($results = $this->create())
-				? array_column($results, $property)
+	public function createAndResolveTo( $property ): Closure {
+		return function() use ( $property ) {
+			return is_array( $results = $this->create() )
+				? array_column( $results, $property )
 				: $results->$property;
 		};
 	}
@@ -102,15 +101,20 @@ abstract class ModelFactory {
 	/**
 	 * Creates an instance of the model from the attributes and definition.
 	 *
-	 * @unreleased Add support for resolving Closures.
+	 * @since 1.2.3 Add support for resolving Closures.
 	 * @since 1.0.0
 	 *
 	 * @return M
 	 */
 	protected function makeInstance( array $attributes ) {
-		return new $this->model(array_map(function($attribute) {
-			return $attribute instanceof Closure ? $attribute() : $attribute;
-		}, array_merge($this->definition(), $attributes)));
+		return new $this->model(
+			array_map(
+				function( $attribute ) {
+					return $attribute instanceof Closure ? $attribute() : $attribute;
+				},
+				array_merge( $this->definition(), $attributes )
+			)
+		);
 	}
 
 	/**

--- a/src/Models/ModelFactory.php
+++ b/src/Models/ModelFactory.php
@@ -2,6 +2,7 @@
 
 namespace StellarWP\Models;
 
+use Closure;
 use Exception;
 use StellarWP\DB\DB;
 
@@ -54,6 +55,18 @@ abstract class ModelFactory {
 	}
 
 	/**
+	 * @unreleased
+	 */
+	public function makeAndResolveTo($property): Closure
+	{
+		return function() use ($property) {
+			return is_array($results = $this->make())
+				? array_column($results, $property)
+				: $results->$property;
+		};
+	}
+
+	/**
 	 * @since 1.0.0
 	 *
 	 * @param array $attributes
@@ -75,14 +88,29 @@ abstract class ModelFactory {
 	}
 
 	/**
+	 * @unreleased
+	 */
+	public function createAndResolveTo($property): Closure
+	{
+		return function() use ($property) {
+			return is_array($results = $this->create())
+				? array_column($results, $property)
+				: $results->$property;
+		};
+	}
+
+	/**
 	 * Creates an instance of the model from the attributes and definition.
 	 *
+	 * @unreleased Add support for resolving Closures.
 	 * @since 1.0.0
 	 *
 	 * @return M
 	 */
 	protected function makeInstance( array $attributes ) {
-		return new $this->model( array_merge( $this->definition(), $attributes ) );
+		return new $this->model(array_map(function($attribute) {
+			return $attribute instanceof Closure ? $attribute() : $attribute;
+		}, array_merge($this->definition(), $attributes)));
 	}
 
 	/**

--- a/tests/wpunit/ModelFactoryTest.php
+++ b/tests/wpunit/ModelFactoryTest.php
@@ -1,0 +1,369 @@
+<?php
+
+namespace StellarWP\Models;
+
+use Exception;
+use StellarWP\Models\Tests\ModelsTestCase;
+
+/**
+ * @unreleased
+ *
+ * @coversDefaultClass \StellarWP\Models\ModelFactory
+ */
+class ModelFactoryTest extends ModelsTestCase
+{
+	/**
+	 * @unreleased
+	 */
+	public function setUp()
+	{
+		parent::setUp();
+		MockModel::resetAutoIncrementId();
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testDefinitionAsAttributes()
+	{
+		$factory = new class(MockModel::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					'id' => 123,
+				];
+			}
+		};
+
+		$object = $factory->make();
+
+		$this->assertEquals(123, $object->id);
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testPassedAttributesOverrideDefinition()
+	{
+		$factory = new class(MockModel::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					'id' => 123,
+				];
+			}
+		};
+
+		$object = $factory->make([
+			'id' => 456,
+		]);
+
+		$this->assertEquals(456, $object->id);
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testResolvesCallableDefinitions()
+	{
+		$factory = new class(MockModel::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					'id' => function() {
+						return 123;
+					},
+				];
+			}
+		};
+
+		$object = $factory->make();
+
+		$this->assertEquals(123, $object->id);
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testDoesNotResolveCallableWhenPassedAttribute()
+	{
+		$factory = new class(MockModel::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					'id' => function() {
+						throw new Exception('Should not be called');
+					},
+				];
+			}
+		};
+
+		$object = $factory->make([
+			'id' => 123,
+		]);
+
+		$this->assertEquals(123, $object->id);
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testMakeResolvesDependencyDefinition()
+	{
+		$factory = new class(MockModelWithDependency::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					'id' => 123,
+				];
+			}
+		};
+
+		$nestedFactory = new class(MockModel::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					'id' => 789,
+				];
+			}
+		};
+
+		$object = $factory->make([
+			'nestedId' => $nestedFactory->makeAndResolveTo('id'),
+		]);
+
+		$this->assertEquals(789, $object->nestedId);
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testMakeResolvesDependencyDefinitionWithCount()
+	{
+		$factory = new class(MockModelWithDependency::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					'id' => 123,
+				];
+			}
+		};
+
+		$nestedFactory = new class(MockModel::class) extends ModelFactory {
+			public function definition(): array {
+				static $counter = 1;
+				return [
+					'id' => $counter++,
+				];
+			}
+		};
+
+		$instances = $factory->count(2)->make([
+			'nestedId' => $nestedFactory->makeAndResolveTo('id'),
+		]);
+
+		$this->assertIsArray($instances);
+		$this->assertEquals(1, $instances[0]->nestedId);
+		$this->assertEquals(2, $instances[1]->nestedId);
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testMakeDoesNotResolveDependencyWhenPassedAttribute()
+	{
+		$factory = new class(MockModelWithDependency::class) extends ModelFactory {
+			public function definition(): array {
+
+				$nestedFactory = new class(MockModel::class) extends ModelFactory {
+					public function definition(): array {
+						return [
+							'id' => 456,
+						];
+					}
+
+					public function make(array $attributes = [])
+					{
+						throw new Exception('Should not be called');
+					}
+				};
+
+				return [
+					'id' => 123,
+					'nestedId' => $nestedFactory->makeAndResolveTo('id')
+				];
+			}
+		};
+
+		$object = $factory->make([
+			'nestedId' => 789,
+		]);
+
+		$this->assertEquals(789, $object->nestedId);
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testCreateResolvesDependencyDefinition()
+	{
+		$factory = new class(MockModelWithDependency::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					'id' => 123,
+				];
+			}
+		};
+
+		$nestedFactory = new class(MockModel::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					// Defer id assignment until save
+				];
+			}
+		};
+
+		$object = $factory->create([
+			'nestedId' => $nestedFactory->createAndResolveTo('id'),
+		]);
+
+		$this->assertEquals(1, $object->nestedId);
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testCreateResolvesDependencyDefinitionWithCount()
+	{
+		$factory = new class(MockModelWithDependency::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					'id' => 123,
+				];
+			}
+		};
+
+		$nestedFactory = new class(MockModel::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					// Defer id assignment until save
+				];
+			}
+		};
+
+		$instances = $factory->count(2)->make([
+			'nestedId' => $nestedFactory->createAndResolveTo('id'),
+		]);
+
+		$this->assertIsArray($instances);
+		$this->assertEquals(1, $instances[0]->nestedId);
+		$this->assertEquals(2, $instances[1]->nestedId);
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testCreateDoesNotResolveDependencyWhenPassedAttribute()
+	{
+		$factory = new class(MockModelWithDependency::class) extends ModelFactory {
+			public function definition(): array {
+
+				$nestedFactory = new class(MockModel::class) extends ModelFactory {
+					public function definition(): array {
+						return [
+							// Defer id assignment until save
+						];
+					}
+
+					public function create(array $attributes = [])
+					{
+						throw new Exception('Should not be called');
+					}
+				};
+
+				return [
+					'id' => 123,
+					'nestedId' => $nestedFactory->createAndResolveTo('id')
+				];
+			}
+		};
+
+		$object = $factory->make([
+			'nestedId' => 789,
+		]);
+
+		$this->assertEquals(789, $object->nestedId);
+	}
+
+	/**
+	 * @unreleased
+	 */
+	public function testDoesNotResolveInvokableClasses()
+	{
+		$factory = new class(MockModelWithInvokableProperty::class) extends ModelFactory {
+			public function definition(): array {
+				return [
+					'invokable' => new class extends MockInvokableClass {
+						public function __invoke() {
+							throw new \Exception('Invokable classes should not be resolved by factories.');
+						}
+					},
+				];
+			}
+		};
+
+		$object = $factory->make();
+
+		$this->assertInstanceOf(MockInvokableClass::class, $object->invokable);
+	}
+}
+
+/**
+ * @unreleased
+ *
+ * @property int $id
+ */
+class MockModel extends Model
+{
+	protected static $autoIncrementId = 1;
+
+	protected $properties = [
+		'id' => 'int',
+	];
+
+	public function save() {
+		$this->id = $this->id ?: self::$autoIncrementId++;
+		return $this;
+	}
+
+	public static function resetAutoIncrementId() {
+		self::$autoIncrementId = 1;
+	}
+}
+
+/**
+ * @unreleased
+ *
+ * @property int $id
+ * @property int $nestedId
+ */
+class MockModelWithDependency extends MockModel
+{
+	protected $properties = [
+		'id' => 'int',
+		'nestedId' => 'int',
+	];
+}
+
+/**
+ * @unreleased
+ */
+abstract class MockInvokableClass
+{
+	abstract public function __invoke();
+}
+
+/**
+ * @unreleased
+ *
+ * @property MockInvokableClass $invokable
+ */
+class MockModelWithInvokableProperty extends MockModel
+{
+	protected $properties = [
+		'invokable' => MockInvokableClass::class,
+	];
+}

--- a/tests/wpunit/ModelFactoryTest.php
+++ b/tests/wpunit/ModelFactoryTest.php
@@ -6,14 +6,14 @@ use Exception;
 use StellarWP\Models\Tests\ModelsTestCase;
 
 /**
- * @unreleased
+ * @since 1.2.3
  *
  * @coversDefaultClass \StellarWP\Models\ModelFactory
  */
 class ModelFactoryTest extends ModelsTestCase
 {
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function setUp()
 	{
@@ -22,7 +22,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testDefinitionAsAttributes()
 	{
@@ -40,7 +40,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testPassedAttributesOverrideDefinition()
 	{
@@ -60,7 +60,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testResolvesCallableDefinitions()
 	{
@@ -80,7 +80,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testDoesNotResolveCallableWhenPassedAttribute()
 	{
@@ -102,7 +102,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testMakeResolvesDependencyDefinition()
 	{
@@ -130,7 +130,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testMakeResolvesDependencyDefinitionWithCount()
 	{
@@ -161,7 +161,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testMakeDoesNotResolveDependencyWhenPassedAttribute()
 	{
@@ -196,7 +196,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testCreateResolvesDependencyDefinition()
 	{
@@ -224,7 +224,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testCreateResolvesDependencyDefinitionWithCount()
 	{
@@ -254,7 +254,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testCreateDoesNotResolveDependencyWhenPassedAttribute()
 	{
@@ -289,7 +289,7 @@ class ModelFactoryTest extends ModelsTestCase
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 */
 	public function testDoesNotResolveInvokableClasses()
 	{
@@ -312,7 +312,7 @@ class ModelFactoryTest extends ModelsTestCase
 }
 
 /**
- * @unreleased
+ * @since 1.2.3
  *
  * @property int $id
  */
@@ -335,7 +335,7 @@ class MockModel extends Model
 }
 
 /**
- * @unreleased
+ * @since 1.2.3
  *
  * @property int $id
  * @property int $nestedId
@@ -349,7 +349,7 @@ class MockModelWithDependency extends MockModel
 }
 
 /**
- * @unreleased
+ * @since 1.2.3
  */
 abstract class MockInvokableClass
 {
@@ -357,7 +357,7 @@ abstract class MockInvokableClass
 }
 
 /**
- * @unreleased
+ * @since 1.2.3
  *
  * @property MockInvokableClass $invokable
  */

--- a/tests/wpunit/ModelTest.php
+++ b/tests/wpunit/ModelTest.php
@@ -278,7 +278,7 @@ class TestModel extends ModelsTestCase {
 	}
 
 	/**
-	 * @since 1.2.3
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */

--- a/tests/wpunit/ModelTest.php
+++ b/tests/wpunit/ModelTest.php
@@ -278,7 +278,7 @@ class TestModel extends ModelsTestCase {
 	}
 
 	/**
-	 * @unreleased
+	 * @since 1.2.3
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

Related https://github.com/impress-org/givewp/pull/7626

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds deferred resolution to model factory definitions, such as nested model factories, so that defaults can be overridden without instantiating unused model instances.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Updates `src\Models\Factories\ModelFactory::makeInstance()` to support resolving attributes that are `callable`.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->

```php
public function definition(): array
{
    return [
        'title' => __('GiveWP Campaign', 'give'),
        'formId' => DonationForm::factory()->createAndResolveTo('id'),
    ];
}
```