### PR TITLE
2.0 — Refactor: Reasonable model methods and properties are made static

### DIFF
--- a/.github/workflows/tests-php.yml
+++ b/.github/workflows/tests-php.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1000
           submodules: recursive
@@ -18,7 +18,7 @@ jobs:
       # Checkout slic
       # ------------------------------------------------------------------------------
       - name: Checkout slic
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: stellarwp/slic
           ref: main
@@ -30,8 +30,8 @@ jobs:
       - name: Get Composer Cache Directory
         id: get-composer-cache-dir
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
         id: composer-cache
         with:
           path: ${{ steps.get-composer-cache-dir.outputs.dir }}

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ class Breakfast_Model extends Model {
 	/**
 	 * @inheritDoc
 	 */
-	static protected $properties = [
+	protected static $properties = [
 		'id'        => 'int',
 		'name'      => 'string',
 		'price'     => 'float',
@@ -95,7 +95,7 @@ class Breakfast_Model extends Model implements Contracts\ModelReadOnly {
 	/**
 	 * @inheritDoc
 	 */
-	static protected $properties = [
+	protected static $properties = [
 		'id'        => 'int',
 		'name'      => 'string',
 		'price'     => 'float',
@@ -136,7 +136,7 @@ class Breakfast_Model extends Model implements Contracts\ModelCrud {
 	/**
 	 * @inheritDoc
 	 */
-	static protected $properties = [
+	protected static $properties = [
 		'id'        => 'int',
 		'name'      => 'string',
 		'price'     => 'float',
@@ -199,7 +199,7 @@ class Breakfast_Model extends Model {
 	/**
 	 * @inheritDoc
 	 */
-	static protected $properties = [
+	protected static $properties = [
 		'id'        => 'int',
 		'name'      => 'string',
 		'price'     => 'float',

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ class Breakfast_Model extends Model {
 	/**
 	 * @inheritDoc
 	 */
-	protected $properties = [
+	static protected $properties = [
 		'id'        => 'int',
 		'name'      => 'string',
 		'price'     => 'float',
@@ -95,7 +95,7 @@ class Breakfast_Model extends Model implements Contracts\ModelReadOnly {
 	/**
 	 * @inheritDoc
 	 */
-	protected $properties = [
+	static protected $properties = [
 		'id'        => 'int',
 		'name'      => 'string',
 		'price'     => 'float',
@@ -136,7 +136,7 @@ class Breakfast_Model extends Model implements Contracts\ModelCrud {
 	/**
 	 * @inheritDoc
 	 */
-	protected $properties = [
+	static protected $properties = [
 		'id'        => 'int',
 		'name'      => 'string',
 		'price'     => 'float',
@@ -199,7 +199,7 @@ class Breakfast_Model extends Model {
 	/**
 	 * @inheritDoc
 	 */
-	protected $properties = [
+	static protected $properties = [
 		'id'        => 'int',
 		'name'      => 'string',
 		'price'     => 'float',

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -103,4 +103,8 @@ class Config {
 
 		static::$invalidArgumentException = $class;
 	}
+
+	public static function throwInvalidArgumentException( string $message ) {
+		throw new static::$invalidArgumentException( $message );
+	}
 }

--- a/src/Models/Contracts/Model.php
+++ b/src/Models/Contracts/Model.php
@@ -67,7 +67,7 @@ interface Model {
 	 *
 	 * @return bool
 	 */
-	public function hasProperty( string $key ) : bool;
+	public static function hasProperty( string $key ) : bool;
 
 	/**
 	 * Determines if a given attribute is clean.
@@ -101,7 +101,7 @@ interface Model {
 	 *
 	 * @return bool
 	 */
-	public function isPropertyTypeValid( string $key, $value ) : bool;
+	public static function isPropertyTypeValid( string $key, $value ) : bool;
 
 	/**
 	 * Returns the property keys.

--- a/src/Models/Contracts/Model.php
+++ b/src/Models/Contracts/Model.php
@@ -61,6 +61,7 @@ interface Model {
 	/**
 	 * Determines if the model has the given property.
 	 *
+	 * @since 2.0.0 changed to static
 	 * @since 1.0.0
 	 *
 	 * @param string $key Property name.
@@ -94,6 +95,7 @@ interface Model {
 	/**
 	 * Validates an attribute to a PHP type.
 	 *
+	 * @since 2.0.0 changed to static
 	 * @since 1.0.0
 	 *
 	 * @param string $key   Attribute name.
@@ -106,6 +108,7 @@ interface Model {
 	/**
 	 * Returns the property keys.
 	 *
+	 * @since 2.0.0 changed to static
 	 * @since 1.0.0
 	 *
 	 * @return int[]|string[]

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -221,7 +221,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 			return $this->cachedRelations[ $key ];
 		}
 
-		$relationship = $this->relationships[ $key ];
+		$relationship = static::$relationships[ $key ];
 
 		switch ( $relationship ) {
 			case Relationship::BELONGS_TO:

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -87,7 +87,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 * @throws RuntimeException
 	 */
 	public function getAttribute( string $key, $default = null ) {
-		$this->validatePropertyExists( $key );
+		static::validatePropertyExists( $key );
 
 		return $this->attributes[ $key ] ?? $default;
 	}
@@ -139,6 +139,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Check if there is a default value for a property.
 	 *
+	 * @since 2.0.0 changed to static
 	 * @since 1.2.2
 	 *
 	 * @param string $key Property name.
@@ -152,6 +153,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Returns the default value for a property if one is provided, otherwise null.
 	 *
+	 * @since 2.0.0 changed to static
 	 * @since 1.0.0
 	 *
 	 * @param string $key Property name.
@@ -169,6 +171,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Returns the defaults for all the properties. If a default is omitted it defaults to null.
 	 *
+	 * @since 2.0.0 changed to static
 	 * @since 1.0.0
 	 *
 	 * @return array<string,mixed>
@@ -262,6 +265,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Determines if the model has the given property.
 	 *
+	 * @since 2.0.0 changed to static
 	 * @since 1.0.0
 	 *
 	 * @param string $key Property name.
@@ -305,6 +309,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Validates an attribute to a PHP type.
 	 *
+	 * @since 2.0.0
 	 * @since 1.0.0
 	 *
 	 * @param string $key   Property name.
@@ -428,14 +433,15 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Validates that the given property exists
 	 *
+	 * @since 2.0.0 changed to static
 	 * @since 1.0.0
 	 *
 	 * @param string $key Property name.
 	 *
 	 * @return void
 	 */
-	protected function validatePropertyExists( string $key ) {
-		if ( ! $this->hasProperty( $key ) ) {
+	protected static function validatePropertyExists( string $key ) {
+		if ( ! static::hasProperty( $key ) ) {
 			$exception = Config::getInvalidArgumentException();
 			throw new $exception( "Invalid property. '$key' does not exist." );
 		}
@@ -444,6 +450,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Validates that the given value is a valid type for the given property.
 	 *
+	 * @since 2.0.0 changed to static
 	 * @since 1.0.0
 	 *
 	 * @param string $key   Property name.

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -28,14 +28,14 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @var array<string,string|array>
 	 */
-	static protected $properties = [];
+	protected static $properties = [];
 
 	/**
 	 * The model relationships assigned to their relationship types.
 	 *
 	 * @var array<string,string>
 	 */
-	static protected $relationships = [];
+	protected static $relationships = [];
 
 	/**
 	 * Relationships that have already been loaded and don't need to be loaded again.

--- a/tests/_support/Helper/MockModel.php
+++ b/tests/_support/Helper/MockModel.php
@@ -5,7 +5,7 @@ namespace StellarWP\Models\Tests;
 use StellarWP\Models\Model;
 
 class MockModel extends Model {
-	protected $properties = [
+	protected static $properties = [
 		'id'           => 'int',
 		'firstName'    => [ 'string', 'Michael' ],
 		'lastName'     => 'string',

--- a/tests/_support/Helper/MockModelWithRelationship.php
+++ b/tests/_support/Helper/MockModelWithRelationship.php
@@ -8,11 +8,11 @@ use StellarWP\Models\Model;
 use StellarWP\Models\ValueObjects\Relationship;
 
 class MockModelWithRelationship extends Model {
-	protected $properties = [
+	protected static $properties = [
 		'id' => 'int',
 	];
 
-	protected $relationships = [
+	protected static $relationships = [
 		'relatedButNotCallable'     => Relationship::HAS_ONE,
 		'relatedAndCallableHasOne'  => Relationship::HAS_ONE,
 		'relatedAndCallableHasMany' => Relationship::HAS_MANY,

--- a/tests/wpunit/ModelFactoryTest.php
+++ b/tests/wpunit/ModelFactoryTest.php
@@ -320,7 +320,7 @@ class MockModel extends Model
 {
 	protected static $autoIncrementId = 1;
 
-	protected $properties = [
+	protected static $properties = [
 		'id' => 'int',
 	];
 
@@ -342,7 +342,7 @@ class MockModel extends Model
  */
 class MockModelWithDependency extends MockModel
 {
-	protected $properties = [
+	protected static $properties = [
 		'id' => 'int',
 		'nestedId' => 'int',
 	];
@@ -363,7 +363,7 @@ abstract class MockInvokableClass
  */
 class MockModelWithInvokableProperty extends MockModel
 {
-	protected $properties = [
+	protected static $properties = [
 		'invokable' => MockInvokableClass::class,
 	];
 }

--- a/tests/wpunit/ModelTest.php
+++ b/tests/wpunit/ModelTest.php
@@ -110,9 +110,7 @@ class TestModel extends ModelsTestCase {
 	 * @return void
 	 */
 	public function testIsPropertyTypeValidShouldReturnTrueWhenPropertyIsValid() {
-		$model = new MockModel();
-
-		$this->assertTrue( $model->isPropertyTypeValid( 'id', 1 ) );
+		$this->assertTrue( MockModel::isPropertyTypeValid( 'id', 1 ) );
 	}
 
 	/**
@@ -123,9 +121,7 @@ class TestModel extends ModelsTestCase {
 	 * @return void
 	 */
 	public function testIsPropertyTypeValidShouldReturnFalseWhenPropertyIsInValid( $key, $value ) {
-		$model = new MockModel();
-
-		$this->assertFalse( $model->isPropertyTypeValid( $key, $value ) );
+		$this->assertFalse( MockModel::isPropertyTypeValid( $key, $value ) );
 	}
 
 	/**


### PR DESCRIPTION
Many of the properties and methods of the `Model` class are instance properties for no particular reason. The `Model::$properties` property, for example, is an instance property. But it's really only meant to be defined by the class and then consistent across all subclass instances. In fact, making the properties dynamic on a per-instance basis is an anti-pattern to the model itself, as it's no longer a clearly defined set of data.

The side-effect of these being instance bound is that an instance is required in order to do basic things such as know a model's properties, check if a property is valid, and so forth.

This PR switches a number of properties and methods to be static. Basically those that can be. It updates the interfaces and the `Model` class itself.

Accessing a static method from an instance (e.g. `$model->hasProperty()` is supported in PHP and backwards compatible, but the interfaces and property/method overloading obviously aren't. As such, this is a major change and slated for a 2.0.0 release.