### PR TITLE
Adds support for PHPStan

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,35 @@
+name: 'PHPStan'
+on:
+  push:
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      # ------------------------------------------------------------------------------
+      # Prepare our composer cache directory
+      # ------------------------------------------------------------------------------
+      - name: Get Composer Cache Directory
+        id: get-composer-cache-dir
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        id: composer-cache
+        with:
+          path: ${{ steps.get-composer-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      # ------------------------------------------------------------------------------
+      # Install dependencies
+      # ------------------------------------------------------------------------------
+      - name: Install dependencies
+        run: composer install --ignore-platform-reqs --no-interaction
+      # ------------------------------------------------------------------------------
+      # Run PHPStan
+      # ------------------------------------------------------------------------------
+      - name: Run PHPStan
+        run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "codeception/module-webdriver": "^1.0",
     "codeception/util-universalframework": "^1.0",
     "lucatume/wp-browser": "^3.0.14",
-    "phpunit/phpunit": "~6.0"
+    "phpunit/phpunit": "~6.0",
+    "phpstan/phpstan": "^2.1"
   },
   "autoload": {
     "psr-4": {
@@ -44,5 +45,8 @@
     "psr-4": {
       "StellarWP\\Models\\Tests\\": "tests/_support/Helper/"
     }
+  },
+  "scripts": {
+    "phpstan": "phpstan analyze --memory-limit=512M"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0e34df9a3278e62064b35f1fae70a1b",
+    "content-hash": "fee04c002007ad40c10dd1e955400daf",
     "packages": [
         {
             "name": "stellarwp/db",
@@ -2497,6 +2497,64 @@
                 "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
             },
             "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.29",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phar-composer-source.git",
+                "reference": "git"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d618573eed4a1b6b75e37b2e0b65ac65c885d88e",
+                "reference": "d618573eed4a1b6b75e37b2e0b65ac65c885d88e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-25T06:58:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5416,13 +5474,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
-        "php": "7.0"
+        "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+	level: max
+	paths:
+		- src
+	excludePaths:
+		- tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,4 @@ parameters:
 		- src
 	excludePaths:
 		- tests
+	treatPhpDocTypesAsCertain: false

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -3,6 +3,7 @@
 namespace StellarWP\Models;
 
 use InvalidArgumentException;
+use Throwable;
 
 class Config {
 	/**
@@ -11,7 +12,7 @@ class Config {
 	protected static $hookPrefix;
 
 	/**
-	 * @var string
+	 * @var class-string<Throwable>
 	 */
 	protected static $invalidArgumentException = InvalidArgumentException::class;
 
@@ -40,7 +41,7 @@ class Config {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return string
+	 * @return class-string<Throwable>
 	 */
 	public static function getInvalidArgumentException(): string {
 		return static::$invalidArgumentException;
@@ -111,9 +112,12 @@ class Config {
 	 *
 	 * @param string $message
 	 *
-	 * @return void
+	 * @return never
+	 * @throws Throwable
 	 */
 	public static function throwInvalidArgumentException( string $message ): void {
-		throw new static::$invalidArgumentException( $message );
+		/** @var class-string<Throwable> $exceptionClass */
+		$exceptionClass = static::$invalidArgumentException;
+		throw new $exceptionClass( $message );
 	}
 }

--- a/src/Models/Contracts/Arrayable.php
+++ b/src/Models/Contracts/Arrayable.php
@@ -11,7 +11,7 @@ interface Arrayable {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function toArray() : array;
 }

--- a/src/Models/Contracts/Model.php
+++ b/src/Models/Contracts/Model.php
@@ -44,7 +44,7 @@ interface Model extends ModelBuildsFromData {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	public function getDirty() : array;
 
@@ -131,7 +131,7 @@ interface Model extends ModelBuildsFromData {
 	 * @since 2.0.0 changed to static
 	 * @since 1.0.0
 	 *
-	 * @return int[]|string[]
+	 * @return list<string>
 	 */
 	public static function propertyKeys() : array;
 

--- a/src/Models/Contracts/ModelBuildsFromData.php
+++ b/src/Models/Contracts/ModelBuildsFromData.php
@@ -11,7 +11,7 @@ interface ModelBuildsFromData {
 	/**
 	 * @since 2.0.0
 	 *
-	 * @param array|object $data
+	 * @param array<string,mixed>|object $data
 	 *
 	 * @return Model
 	 */

--- a/src/Models/Contracts/ModelCrud.php
+++ b/src/Models/Contracts/ModelCrud.php
@@ -7,7 +7,7 @@ use StellarWP\Models\ModelQueryBuilder;
 /**
  * @since 1.0.0
  */
-interface ModelCrud {
+interface ModelCrud extends ModelBuildsFromData {
 	/**
 	 * @since 1.0.0
 	 *

--- a/src/Models/Contracts/ModelCrud.php
+++ b/src/Models/Contracts/ModelCrud.php
@@ -20,7 +20,7 @@ interface ModelCrud {
 	/**
 	 * @since 1.0.0
 	 *
-	 * @param array $attributes
+	 * @param array<string,mixed> $attributes
 	 *
 	 * @return Model
 	 */
@@ -43,7 +43,7 @@ interface ModelCrud {
 	/**
 	 * @since 1.0.0
 	 *
-	 * @return ModelQueryBuilder
+	 * @return ModelQueryBuilder<static>
 	 */
 	public static function query();
 }

--- a/src/Models/Contracts/ModelHasFactory.php
+++ b/src/Models/Contracts/ModelHasFactory.php
@@ -11,7 +11,7 @@ interface ModelHasFactory {
 	/**
 	 * @since 1.0.0
 	 *
-	 * @return ModelFactory
+	 * @return ModelFactory<static>
 	 */
 	public static function factory();
 }

--- a/src/Models/Contracts/ModelHasFactory.php
+++ b/src/Models/Contracts/ModelHasFactory.php
@@ -3,11 +3,12 @@
 namespace StellarWP\Models\Contracts;
 
 use StellarWP\Models\ModelFactory;
+use StellarWP\Models\Contracts\ModelCrud;
 
 /**
  * @since 1.0.0
  */
-interface ModelHasFactory {
+interface ModelHasFactory extends ModelCrud {
 	/**
 	 * @since 1.0.0
 	 *

--- a/src/Models/Contracts/ModelReadOnly.php
+++ b/src/Models/Contracts/ModelReadOnly.php
@@ -7,7 +7,7 @@ use StellarWP\Models\ModelQueryBuilder;
 /**
  * @since 1.0.0
  */
-interface ModelReadOnly extends ModelBuildsFromQueryData {
+interface ModelReadOnly extends ModelBuildsFromData {
 	/**
 	 * @since 1.0.0
 	 *
@@ -20,7 +20,7 @@ interface ModelReadOnly extends ModelBuildsFromQueryData {
 	/**
 	 * @since 1.0.0
 	 *
-	 * @return ModelQueryBuilder
+	 * @return ModelQueryBuilder<static>
 	 */
 	public static function query();
 }

--- a/src/Models/DataTransferObject.php
+++ b/src/Models/DataTransferObject.php
@@ -8,7 +8,7 @@ abstract class DataTransferObject {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param $object
+	 * @param object $object
 	 *
 	 * @return self
 	 */

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -25,21 +25,21 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @var array<string,string|array{0:string,1:mixed}>
 	 */
-	protected static $properties = [];
+	protected static array $properties = [];
 
 	/**
 	 * The model relationships assigned to their relationship types.
 	 *
 	 * @var array<string,string>
 	 */
-	protected static $relationships = [];
+	protected static array $relationships = [];
 
 	/**
 	 * Relationships that have already been loaded and don't need to be loaded again.
 	 *
 	 * @var array<string,Model|list<Model>|null>
 	 */
-	private $cachedRelations = [];
+	private array $cachedRelations = [];
 
 	/**
 	 * Constructor.

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -4,7 +4,6 @@ namespace StellarWP\Models;
 
 use InvalidArgumentException;
 use JsonSerializable;
-use RuntimeException;
 use StellarWP\Models\Contracts\Arrayable;
 use StellarWP\Models\Contracts\Model as ModelInterface;
 use StellarWP\Models\ValueObjects\Relationship;
@@ -38,7 +37,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Relationships that have already been loaded and don't need to be loaded again.
 	 *
-	 * @var array<string,Model|list<Model>>
+	 * @var array<string,Model|list<Model>|null>
 	 */
 	private $cachedRelations = [];
 
@@ -59,17 +58,20 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @since 2.0.0
 	 */
-	protected function afterConstruct() {
-		// This method is meant to be overridden by the model to perform actions after the model is constructed.
+	protected function afterConstruct(): void {
 		return;
 	}
+
 	/**
 	 * Casts the value for the type, used when constructing a model from query data. If the model needs to support
 	 * additional types, especially class types, this method can be overridden.
 	 *
+	 * Note: Type casting is performed at runtime based on property definitions. PHPStan cannot statically verify
+	 * the resulting types, so we suppress type-checking errors for the cast operations.
+	 *
 	 * @since 2.0.0 changed to static
 	 *
-	 * @param string $type
+	 * @param ModelPropertyDefinition $definition The property definition.
 	 * @param mixed  $value The query data value to cast, probably a string.
 	 * @param string $property The property being casted.
 	 *
@@ -89,11 +91,12 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 			throw new InvalidArgumentException( "Property '$property' has multiple types: " . implode( ', ', $type ) . ". To support additional types, implement a custom castValueForProperty() method." );
 		}
 
+		// Runtime type casting based on property definition - PHPStan cannot verify this statically
 		switch ( $type[0] ) {
 			case 'int':
-				return (int) $value;
+				return (int) $value; // @phpstan-ignore-line
 			case 'string':
-				return (string) $value;
+				return (string) $value; // @phpstan-ignore-line
 			case 'bool':
 				return (bool) filter_var( $value, FILTER_VALIDATE_BOOLEAN );
 			case 'array':
@@ -203,10 +206,13 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 * @return array<string,ModelPropertyDefinition>
 	 */
 	public static function getPropertyDefinitions(): array {
-		static $definition = null;
+		/** @var array<string,ModelPropertyDefinition>|null $cachedDefinitions */
+		static $cachedDefinitions = null;
 
-		if ( $definition === null ) {
+		if ( $cachedDefinitions === null ) {
 			$definitions = array_merge( static::$properties, static::properties() );
+			/** @var array<string,ModelPropertyDefinition> $processedDefinitions */
+			$processedDefinitions = [];
 
 			foreach ( $definitions as $key => $definition ) {
 				if ( ! is_string( $key ) ) {
@@ -217,13 +223,13 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 					$definition = ModelPropertyDefinition::fromShorthand( $definition );
 				}
 
-				$definitions[ $key ] = $definition->lock();
+				$processedDefinitions[ $key ] = $definition->lock();
 			}
 
-			$definition = $definitions;
+			$cachedDefinitions = $processedDefinitions;
 		}
 
-		return $definition;
+		return $cachedDefinitions;
 	}
 
 	/**
@@ -252,6 +258,36 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	}
 
 	/**
+	 * Checks if a method exists that returns a ModelQueryBuilder instance.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $method Method name.
+	 *
+	 * @return bool
+	 */
+	protected function hasRelationshipMethod( string $method ): bool {
+		if ( ! method_exists( $this, $method ) ) {
+			return false;
+		}
+
+		try {
+			$reflectionMethod = new \ReflectionMethod( $this, $method );
+			$returnType = $reflectionMethod->getReturnType();
+
+			if ( ! $returnType instanceof \ReflectionNamedType ) {
+				return false;
+			}
+
+			$typeName = $returnType->getName();
+
+			return $typeName === ModelQueryBuilder::class || is_subclass_of( $typeName, ModelQueryBuilder::class );
+		} catch ( \ReflectionException $e ) {
+			return false;
+		}
+	}
+
+	/**
 	 * Returns a relationship.
 	 *
 	 * @since 1.0.0
@@ -261,7 +297,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 * @return Model|list<Model>|null
 	 */
 	protected function getRelationship( string $key ) {
-		if ( ! is_callable( [ $this, $key ] ) ) {
+		if ( ! $this->hasRelationshipMethod( $key ) ) {
 			$exception = Config::getInvalidArgumentException();
 			throw new $exception( "$key() does not exist." );
 		}
@@ -270,16 +306,23 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 			return $this->cachedRelations[ $key ];
 		}
 
-		$relationship = static::$relationships[ $key ];
+		/** @var ModelQueryBuilder<Model> $queryBuilder */
+		$queryBuilder = $this->$key();
 
-		switch ( $relationship ) {
+		switch ( static::$relationships[ $key ] ) {
 			case Relationship::BELONGS_TO:
 			case Relationship::HAS_ONE:
-				return $this->cachedRelations[ $key ] = $this->$key()->get();
+				$result = $queryBuilder->get();
+				/** @var Model|null $result */
+				$this->cachedRelations[ $key ] = $result;
+				return $result;
 			case Relationship::HAS_MANY:
 			case Relationship::BELONGS_TO_MANY:
 			case Relationship::MANY_TO_MANY:
-				return $this->cachedRelations[ $key ] = $this->$key()->getAll();
+				$result = $queryBuilder->getAll();
+				/** @var list<Model>|null $result */
+				$this->cachedRelations[ $key ] = $result;
+				return $result;
 		}
 
 		return null;
@@ -413,7 +456,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 
 		$initialValues = [];
 
-		foreach (static::$properties as $key => $type) {
+		foreach (static::$properties as $key => $_) {
 			if ( ! array_key_exists( $key, $data ) ) {
 				// Skip missing properties when BUILD_MODE_IGNORE_MISSING is set
 				if ( $mode & self::BUILD_MODE_IGNORE_MISSING ) {
@@ -422,7 +465,6 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 				Config::throwInvalidArgumentException( "Property '$key' does not exist." );
 			}
 
-			// Remember not to use $type, as it may be an array that includes the default value. Safer to use getPropertyType().
 			$initialValues[ $key ] = static::castValueForProperty( static::getPropertyDefinition( $key ), $data[ $key ], $key );
 		}
 

--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -2,6 +2,7 @@
 
 namespace StellarWP\Models;
 
+use InvalidArgumentException;
 use JsonSerializable;
 use RuntimeException;
 use StellarWP\Models\Contracts\Arrayable;
@@ -23,7 +24,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * The model properties assigned to their types.
 	 *
-	 * @var array<string,string|array>
+	 * @var array<string,string|array{0:string,1:mixed}>
 	 */
 	protected static $properties = [];
 
@@ -37,7 +38,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Relationships that have already been loaded and don't need to be loaded again.
 	 *
-	 * @var Model[]
+	 * @var array<string,Model|list<Model>>
 	 */
 	private $cachedRelations = [];
 
@@ -85,7 +86,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 
 		$type = $definition->getType();
 		if ( count( $type ) !== 1 ) {
-			throw new \InvalidArgumentException( "Property '$property' has multiple types: " . implode( ', ', $type ) . ". To support additional types, implement a custom castValueForProperty() method." );
+			throw new InvalidArgumentException( "Property '$property' has multiple types: " . implode( ', ', $type ) . ". To support additional types, implement a custom castValueForProperty() method." );
 		}
 
 		switch ( $type[0] ) {
@@ -136,7 +137,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * A more robust, alternative way to define properties for the model than static::$properties.
 	 *
-	 * @return array<string,ModelPropertyDefinition|array<string,mixed>>
+	 * @return array<string,ModelPropertyDefinition>
 	 */
 	protected static function properties(): array {
 		return [];
@@ -188,7 +189,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 		$definitions = static::getPropertyDefinitions();
 
 		if ( ! isset( $definitions[ $key ] ) ) {
-			throw new \InvalidArgumentException( 'Property ' . $key . ' does not exist.' );
+			throw new InvalidArgumentException( 'Property ' . $key . ' does not exist.' );
 		}
 
 		return $definitions[ $key ];
@@ -209,7 +210,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 
 			foreach ( $definitions as $key => $definition ) {
 				if ( ! is_string( $key ) ) {
-					throw new \InvalidArgumentException( 'Property key must be a string.' );
+					throw new InvalidArgumentException( 'Property key must be a string.' );
 				}
 
 				if ( ! $definition instanceof ModelPropertyDefinition ) {
@@ -257,7 +258,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @param string $key Relationship name.
 	 *
-	 * @return Model|Model[]
+	 * @return Model|list<Model>|null
 	 */
 	protected function getRelationship( string $key ) {
 		if ( ! is_callable( [ $this, $key ] ) ) {
@@ -384,7 +385,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	/**
 	 * Constructs a model instance from database query data.
 	 *
-	 * @param object|array $queryData
+	 * @param array<string,mixed>|object $data
 	 * @param int $mode The level of strictness to take when constructing the object, by default it will ignore extra keys but error on missing keys.
 	 * @return static
 	 */
@@ -433,7 +434,7 @@ abstract class Model implements ModelInterface, Arrayable, JsonSerializable {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return int[]|string[]
+	 * @return list<string>
 	 */
 	public static function propertyKeys() : array {
 		return array_keys( static::$properties );

--- a/src/Models/ModelFactory.php
+++ b/src/Models/ModelFactory.php
@@ -5,9 +5,10 @@ namespace StellarWP\Models;
 use Closure;
 use Exception;
 use StellarWP\DB\DB;
+use StellarWP\Models\Contracts\ModelCrud;
 
 /**
- * @template M
+ * @template M of ModelCrud
  */
 abstract class ModelFactory {
 	/**

--- a/src/Models/ModelFactory.php
+++ b/src/Models/ModelFactory.php
@@ -59,7 +59,7 @@ abstract class ModelFactory {
 	/**
 	 * @since 1.2.3
 	 */
-	public function makeAndResolveTo($property): Closure
+	public function makeAndResolveTo(string $property): Closure
 	{
 		return function() use ($property) {
 			return is_array($results = $this->make())
@@ -92,7 +92,7 @@ abstract class ModelFactory {
 	/**
 	 * @since 1.2.3
 	 */
-	public function createAndResolveTo( $property ): Closure {
+	public function createAndResolveTo( string $property ): Closure {
 		return function() use ( $property ) {
 			return is_array( $results = $this->create() )
 				? array_column( $results, $property )
@@ -106,6 +106,7 @@ abstract class ModelFactory {
 	 * @since 1.2.3 Add support for resolving Closures.
 	 * @since 1.0.0
 	 *
+	 * @param array<string,mixed> $attributes
 	 * @return M
 	 */
 	protected function makeInstance( array $attributes ) {
@@ -123,6 +124,8 @@ abstract class ModelFactory {
 	 * Configure the factory.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @return ModelFactory<M>
 	 */
 	public function configure() : self {
 		return $this;
@@ -132,6 +135,8 @@ abstract class ModelFactory {
 	 * Sets the number of models to generate.
 	 *
 	 * @since 1.0.0
+	 *
+	 * @return ModelFactory<M>
 	 */
 	public function count( int $count ) : self {
 		$this->count = $count;

--- a/src/Models/ModelFactory.php
+++ b/src/Models/ModelFactory.php
@@ -33,15 +33,17 @@ abstract class ModelFactory {
 
 	/**
 	 * Define the model's default state.
+	 *
+	 * @return array<string,mixed>
 	 */
 	abstract public function definition() : array;
 
 	/**
 	 * @since 1.0.0
 	 *
-	 * @param array $attributes
+	 * @param array<string,mixed> $attributes
 	 *
-	 * @return M|M[]
+	 * @return M|list<M>
 	 */
 	public function make( array $attributes = [] ) {
 		$results = [];
@@ -69,9 +71,9 @@ abstract class ModelFactory {
 	/**
 	 * @since 1.0.0
 	 *
-	 * @param array $attributes
+	 * @param array<string,mixed> $attributes
 	 *
-	 * @return M|M[]
+	 * @return M|list<M>
 	 * @throws Exception
 	 */
 	public function create( array $attributes = [] ) {

--- a/src/Models/ModelProperty.php
+++ b/src/Models/ModelProperty.php
@@ -83,6 +83,8 @@ class ModelProperty {
 	 * Get the original value of the property.
 	 *
 	 * @since 2.0.0
+	 *
+	 * @return mixed
 	 */
 	public function getOriginalValue() {
 		return $this->originalValue;
@@ -92,6 +94,8 @@ class ModelProperty {
 	 * Get the value of the property.
 	 *
 	 * @since 2.0.0
+	 *
+	 * @return mixed
 	 */
 	public function getValue() {
 		return $this->value ?? null;
@@ -153,6 +157,8 @@ class ModelProperty {
 	 * Sets the value of the property.
 	 *
 	 * @since 2.0.0
+	 *
+	 * @param mixed $value
 	 */
 	public function setValue( $value ): self {
 		if ( ! $this->definition->isValidValue( $value ) ) {

--- a/src/Models/ModelProperty.php
+++ b/src/Models/ModelProperty.php
@@ -26,11 +26,15 @@ class ModelProperty {
 
 	/**
 	 * The original value of the property.
+	 *
+	 * @var mixed
 	 */
 	private $originalValue;
 
 	/**
 	 * The property value.
+	 *
+	 * @var mixed
 	 */
 	private $value;
 

--- a/src/Models/ModelPropertyCollection.php
+++ b/src/Models/ModelPropertyCollection.php
@@ -67,7 +67,8 @@ class ModelPropertyCollection implements Countable, IteratorAggregate {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param $mode The mode as used in array_filter() which determines the arguments passed to the callback.
+	 * @param callable(ModelProperty,string):bool $callback
+	 * @param int $mode The mode as used in array_filter() which determines the arguments passed to the callback.
 	 */
 	public function filter( callable $callback, $mode = 0 ): ModelPropertyCollection {
 		return new self( array_filter( $this->properties, $callback, $mode ) );
@@ -134,6 +135,8 @@ class ModelPropertyCollection implements Countable, IteratorAggregate {
 	 * Get the dirty values of the properties.
 	 *
 	 * @since 2.0.0
+	 *
+	 * @return array<string,mixed>
 	 */
 	public function getDirtyValues(): array {
 		return $this->getDirtyProperties()->map( fn( ModelProperty $property ) => $property->getValue() );
@@ -185,6 +188,8 @@ class ModelPropertyCollection implements Countable, IteratorAggregate {
 	 * Get the values of the properties.
 	 *
 	 * @since 2.0.0
+	 *
+	 * @return array<string,mixed>
 	 */
 	public function getValues(): array {
 		return $this->map( fn( ModelProperty $property ) => $property->getValue() );
@@ -230,7 +235,10 @@ class ModelPropertyCollection implements Countable, IteratorAggregate {
 	 * Map the properties. This does not use array_map because we want to preserve the keys.
 	 *
 	 * @since 2.0.0
-	 * @return array<string,mixed>
+	 *
+	 * @template TMapValue
+	 * @param callable(ModelProperty):TMapValue $callback
+	 * @return array<string,TMapValue>
 	 */
 	public function map( callable $callback ) {
 		return $this->reduce( static function( $carry, ModelProperty $property ) use ( $callback ) {
@@ -244,6 +252,12 @@ class ModelPropertyCollection implements Countable, IteratorAggregate {
 	 * Reduce the properties.
 	 *
 	 * @since 2.0.0
+	 *
+	 * @template TReduceInitial
+	 * @template TReduceResult
+	 * @param callable(TReduceResult,ModelProperty):TReduceResult $callback
+	 * @param TReduceInitial $initial
+	 * @return TReduceResult|TReduceInitial
 	 */
 	public function reduce( callable $callback, $initial = null ) {
 		return array_reduce( $this->properties, $callback, $initial );
@@ -271,6 +285,8 @@ class ModelPropertyCollection implements Countable, IteratorAggregate {
 	 * Set the values of the properties.
 	 *
 	 * @since 2.0.0
+	 *
+	 * @param array<string,mixed> $values
 	 */
 	public function setValues( array $values ) {
 		foreach ( $values as $key => $value ) {
@@ -282,6 +298,13 @@ class ModelPropertyCollection implements Countable, IteratorAggregate {
 		}
 	}
 
+	/**
+	 * Execute a callback on each property and return the collection.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param callable(ModelProperty):void $callback
+	 */
 	public function tap( callable $callback ): self {
 		foreach ( $this->properties as $property ) {
 			$callback( $property );

--- a/src/Models/ModelPropertyCollection.php
+++ b/src/Models/ModelPropertyCollection.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace StellarWP\Models;
 
+use Countable;
+use InvalidArgumentException;
+use IteratorAggregate;
+
 /**
  * A collection of properties for a model.
  *
  * Some philosophical notes:
  * 		* The collection is immutable. Once created, the collection cannot be changed.
+ *
+ * @implements IteratorAggregate<string,ModelProperty>
  */
-class ModelPropertyCollection implements \Countable, \IteratorAggregate {
+class ModelPropertyCollection implements Countable, IteratorAggregate {
 	/**
 	 * The properties.
 	 *
@@ -27,11 +33,11 @@ class ModelPropertyCollection implements \Countable, \IteratorAggregate {
 	public function __construct( array $properties = [] ) {
 		foreach ( $properties as $key => $property ) {
 			if ( ! is_string( $key ) ) {
-				throw new \InvalidArgumentException( 'Property key must be a string.' );
+				throw new InvalidArgumentException( 'Property key must be a string.' );
 			}
 
 			if ( ! $property instanceof ModelProperty ) {
-				throw new \InvalidArgumentException( 'Property must be an instance of ModelProperty.' );
+				throw new InvalidArgumentException( 'Property must be an instance of ModelProperty.' );
 			}
 
 			$this->properties[$key] = $property;
@@ -80,11 +86,11 @@ class ModelPropertyCollection implements \Countable, \IteratorAggregate {
 
 		foreach ( $propertyDefinitions as $key => $definition ) {
 			if ( ! is_string( $key ) ) {
-				throw new \InvalidArgumentException( 'Property key must be a string.' );
+				throw new InvalidArgumentException( 'Property key must be a string.' );
 			}
 
 			if ( ! $definition instanceof ModelPropertyDefinition ) {
-				throw new \InvalidArgumentException( 'Property definition must be an instance of ModelPropertyDefinition.' );
+				throw new InvalidArgumentException( 'Property definition must be an instance of ModelPropertyDefinition.' );
 			}
 
 			if ( isset( $initialValues[$key] ) ) {
@@ -140,7 +146,7 @@ class ModelPropertyCollection implements \Countable, \IteratorAggregate {
 	 */
 	public function getOrFail( string $key ): ModelProperty {
 		if ( ! $this->has( $key ) ) {
-			throw new \InvalidArgumentException( 'Property ' . $key . ' does not exist.' );
+			throw new InvalidArgumentException( 'Property ' . $key . ' does not exist.' );
 		}
 
 		return $this->properties[$key];
@@ -269,7 +275,7 @@ class ModelPropertyCollection implements \Countable, \IteratorAggregate {
 	public function setValues( array $values ) {
 		foreach ( $values as $key => $value ) {
 			if ( ! $this->has( $key ) ) {
-				throw new \InvalidArgumentException( 'Property ' . $key . ' does not exist.' );
+				throw new InvalidArgumentException( 'Property ' . $key . ' does not exist.' );
 			}
 
 			$this->properties[$key]->setValue( $value );

--- a/src/Models/ModelPropertyDefinition.php
+++ b/src/Models/ModelPropertyDefinition.php
@@ -28,7 +28,7 @@ class ModelPropertyDefinition {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @var Closure|null A closure that accepts the value and property instance as parameters and returns the cast value.
+	 * @var Closure A closure that accepts the value and property instance as parameters and returns the cast value.
 	 */
 	private Closure $castMethod;
 
@@ -274,6 +274,7 @@ class ModelPropertyDefinition {
 			case 'double':
 				return $this->supportsType( 'float' );
 			case 'object':
+				/** @var object $value */
 				if ( $this->supportsType( 'object' ) ) {
 					return true;
 				} else {

--- a/src/Models/ModelPropertyDefinition.php
+++ b/src/Models/ModelPropertyDefinition.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace StellarWP\Models;
 
 use Closure;
+use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * Defines a model property with its type, default value, and validation rules.
@@ -108,13 +110,13 @@ class ModelPropertyDefinition {
 	 *
 	 * @return mixed
 	 *
-	 * @throws \RuntimeException When no cast method is set.
+	 * @throws RuntimeException When no cast method is set.
 	 */
 	public function cast( $value ) {
 		$this->checkLock();
 
 		if ( ! $this->canCast() ) {
-			throw new \RuntimeException( 'No cast method set' );
+			throw new RuntimeException( 'No cast method set' );
 		}
 
 		$castMethod = $this->castMethod;
@@ -140,11 +142,11 @@ class ModelPropertyDefinition {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @throws \RuntimeException When the property is locked.
+	 * @throws RuntimeException When the property is locked.
 	 */
 	private function checkLock(): void {
 		if ( $this->locked ) {
-			throw new \RuntimeException( 'Property is locked' );
+			throw new RuntimeException( 'Property is locked' );
 		}
 	}
 
@@ -155,7 +157,7 @@ class ModelPropertyDefinition {
 	 *
 	 * @param string|array{0:string,1:mixed} $definition The shorthand definition.
 	 *
-	 * @throws \InvalidArgumentException When the definition is invalid.
+	 * @throws InvalidArgumentException When the definition is invalid.
 	 */
 	public static function fromShorthand( $definition ): self {
 		$property = new self();
@@ -166,7 +168,7 @@ class ModelPropertyDefinition {
 			$property->type( $definition[0] );
 			$property->default( $definition[1] );
 		} else {
-			throw new \InvalidArgumentException( 'Invalid shorthand property definition' );
+			throw new InvalidArgumentException( 'Invalid shorthand property definition' );
 		}
 
 		// Nullable for backwards compatibility

--- a/src/Models/ModelQueryBuilder.php
+++ b/src/Models/ModelQueryBuilder.php
@@ -48,7 +48,9 @@ class ModelQueryBuilder extends QueryBuilder {
 		}
 		$this->selects[] = new RawSQL( 'SELECT COUNT(%1s) AS count', $column );
 
-		return +parent::get()->count;
+		/** @var object{count:numeric-string} $result */
+		$result = parent::get();
+		return (int) $result->count;
 	}
 
 	/**
@@ -79,7 +81,7 @@ class ModelQueryBuilder extends QueryBuilder {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return M[]|null
+	 * @return list<M>|null
 	 */
 	public function getAll( $output = self::MODEL ) : ?array {
 		if ( $output !== self::MODEL ) {

--- a/src/Models/ModelQueryBuilder.php
+++ b/src/Models/ModelQueryBuilder.php
@@ -40,7 +40,7 @@ class ModelQueryBuilder extends QueryBuilder {
 	 *
 	 * @param null|string $column
 	 */
-	public function count( ?string $column = null ) : int {
+	public function count( $column = null ) : int {
 		$column = ( ! $column || $column === '*' ) ? '1' : trim( $column );
 
 		if ( '1' === $column ) {
@@ -60,10 +60,11 @@ class ModelQueryBuilder extends QueryBuilder {
 	 *
 	 * @param string $output
 	 *
-	 * @return M|null
+	 * @return M|array<string,mixed>|object|null
 	 */
-	public function get( $output = self::MODEL ): ?Model {
+	public function get( $output = self::MODEL ) {
 		if ( $output !== self::MODEL ) {
+			/** @var array<string,mixed>|object|null */
 			return parent::get( $output );
 		}
 
@@ -73,6 +74,7 @@ class ModelQueryBuilder extends QueryBuilder {
 			return null;
 		}
 
+		/** @var array<string,mixed>|object $row */
 		return $this->model::fromData( $row );
 	}
 
@@ -81,19 +83,22 @@ class ModelQueryBuilder extends QueryBuilder {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return list<M>|null
+	 * @return list<M|array<string,mixed>|object>|null
 	 */
 	public function getAll( $output = self::MODEL ) : ?array {
 		if ( $output !== self::MODEL ) {
+			/** @var list<array<string,mixed>|object>|null */
 			return parent::getAll( $output );
 		}
 
+		/** @var list<object> */
 		$results = DB::get_results( $this->getSQL() );
 
 		if ( ! $results ) {
 			return null;
 		}
 
+		/** @var list<M> */
 		return array_map( [ $this->model, 'fromData' ], $results );
 	}
 }

--- a/src/Models/Repositories/Repository.php
+++ b/src/Models/Repositories/Repository.php
@@ -2,15 +2,19 @@
 
 namespace StellarWP\Models\Repositories;
 
+use StellarWP\Models\Contracts\ModelBuildsFromData;
 use StellarWP\Models\ModelQueryBuilder;
 
+/**
+ * @template M of ModelBuildsFromData
+ */
 abstract class Repository {
 	/**
 	 * Prepare a query builder for the repository.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return ModelQueryBuilder
+	 * @return ModelQueryBuilder<M>
 	 */
 	abstract function prepareQuery() : ModelQueryBuilder;
 }

--- a/tests/_support/Helper/MockModel.php
+++ b/tests/_support/Helper/MockModel.php
@@ -5,7 +5,7 @@ namespace StellarWP\Models\Tests;
 use StellarWP\Models\Model;
 
 class MockModel extends Model {
-	protected static $properties = [
+	protected static array $properties = [
 		'id'           => 'int',
 		'firstName'    => [ 'string', 'Michael' ],
 		'lastName'     => 'string',

--- a/tests/_support/Helper/MockModelWithAfterConstruct.php
+++ b/tests/_support/Helper/MockModelWithAfterConstruct.php
@@ -13,7 +13,7 @@ class MockModelWithAfterConstruct extends Model {
 	public bool $afterConstructCalled = false;
 	public array $constructedAttributes = [];
 
-	protected function afterConstruct() {
+	protected function afterConstruct(): void {
 		$this->afterConstructCalled = true;
 		$this->constructedAttributes = $this->toArray();
 	}

--- a/tests/_support/Helper/MockModelWithAfterConstruct.php
+++ b/tests/_support/Helper/MockModelWithAfterConstruct.php
@@ -5,7 +5,7 @@ namespace StellarWP\Models\Tests;
 use StellarWP\Models\Model;
 
 class MockModelWithAfterConstruct extends Model {
-	protected static $properties = [
+	protected static array $properties = [
 		'id' => 'int',
 		'name' => 'string',
 	];

--- a/tests/_support/Helper/MockModelWithRelationship.php
+++ b/tests/_support/Helper/MockModelWithRelationship.php
@@ -2,17 +2,16 @@
 
 namespace StellarWP\Models\Tests;
 
-use StellarWP\DB\DB;
 use StellarWP\Models\Model;
 use StellarWP\Models\ModelQueryBuilder;
 use StellarWP\Models\ValueObjects\Relationship;
 
 class MockModelWithRelationship extends Model {
-	protected static $properties = [
+	protected static array $properties = [
 		'id' => 'int',
 	];
 
-	protected static $relationships = [
+	protected static array $relationships = [
 		'relatedButNotCallable'     => Relationship::HAS_ONE,
 		'relatedAndCallableHasOne'  => Relationship::HAS_ONE,
 		'relatedAndCallableHasMany' => Relationship::HAS_MANY,

--- a/tests/_support/Helper/MockModelWithRelationship.php
+++ b/tests/_support/Helper/MockModelWithRelationship.php
@@ -3,8 +3,8 @@
 namespace StellarWP\Models\Tests;
 
 use StellarWP\DB\DB;
-use StellarWP\DB\QueryBuilder\QueryBuilder;
 use StellarWP\Models\Model;
+use StellarWP\Models\ModelQueryBuilder;
 use StellarWP\Models\ValueObjects\Relationship;
 
 class MockModelWithRelationship extends Model {
@@ -19,16 +19,16 @@ class MockModelWithRelationship extends Model {
 	];
 
 	/**
-	 * @return QueryBuilder
+	 * @return ModelQueryBuilder<MockModel>
 	 */
-	public function relatedAndCallableHasOne() {
-		return DB::table( 'posts' );
+	public function relatedAndCallableHasOne(): ModelQueryBuilder {
+		return ( new ModelQueryBuilder( MockModel::class ) )->from( 'posts' );
 	}
 
 	/**
-	 * @return QueryBuilder
+	 * @return ModelQueryBuilder<MockModel>
 	 */
-	public function relatedAndCallableHasMany() {
-		return DB::table( 'posts' );
+	public function relatedAndCallableHasMany(): ModelQueryBuilder {
+		return ( new ModelQueryBuilder( MockModel::class ) )->from( 'posts' );
 	}
 }

--- a/tests/wpunit/ModelFactoryTest.php
+++ b/tests/wpunit/ModelFactoryTest.php
@@ -318,7 +318,7 @@ class MockModel extends Model
 {
 	protected static $autoIncrementId = 1;
 
-	protected static $properties = [
+	protected static array $properties = [
 		'id' => 'int',
 	];
 
@@ -340,7 +340,7 @@ class MockModel extends Model
  */
 class MockModelWithDependency extends MockModel
 {
-	protected static $properties = [
+	protected static array $properties = [
 		'id' => 'int',
 		'nestedId' => 'int',
 	];
@@ -363,7 +363,7 @@ class MockInvokableClass
  */
 class MockModelWithInvokableProperty extends MockModel
 {
-	protected static $properties = [
+	protected static array $properties = [
 		'invokable' => MockInvokableClass::class,
 	];
 }


### PR DESCRIPTION
This adds PHPStan in strict mode for this project. It also does a fair bit of refactoring of types — very little logic refactoring — as the result of things caught by strict mode. I tried to avoid inline `@var`, but preferred it over just ignoring PHPStan. There are certain areas we can't really avoid, such as places using other packages. But overall I'm pretty happy with what all was done!