### PR TITLE
Feature: Read-only properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ class Breakfast_Model extends Model {
 		return [
 			'id' => ModelPropertyDefinition::create()
 				->type('int')
-				->required(),
+				->required()
 			'name' => ModelPropertyDefinition::create()
 				->type('string')
 				->default('Default Name')
@@ -106,6 +106,16 @@ class Breakfast_Model extends Model {
 	}
 }
 ```
+
+#### Property definition options:
+
+- `type(string ...$types)` - Set one or more types (int, string, bool, float, array, or class names)
+- `default($value)` - Set a default value (can be a closure)
+- `nullable()` - Allow null values
+- `required()` - Property must be provided during construction
+- `requiredOnSave()` - Property must be set before saving
+- `readonly()` - Property can only be set during construction, cannot be modified afterward
+- `castWith(callable $callback)` - Custom casting function for the property value
 
 ### A persistable model
 
@@ -264,6 +274,44 @@ Build modes:
 - `BUILD_MODE_STRICT`: Throws exceptions for missing or extra properties
 - `BUILD_MODE_IGNORE_MISSING`: Ignores properties missing from the data
 - `BUILD_MODE_IGNORE_EXTRA`: Ignores extra properties in the data (default)
+
+### Readonly properties
+
+Properties marked as `readonly()` can only be set during construction and cannot be modified afterward:
+
+```php
+use Boomshakalaka\StellarWP\Models\Model;
+use Boomshakalaka\StellarWP\Models\ModelPropertyDefinition;
+
+class User_Model extends Model {
+	protected static function properties(): array {
+		return [
+			'id' => ModelPropertyDefinition::create()
+				->type('int')
+				->readonly(), // Can only be set during construction
+			'email' => ModelPropertyDefinition::create()
+				->type('string'),
+		];
+	}
+}
+
+// Set readonly property during construction
+$user = new User_Model(['id' => 1, 'email' => 'user@example.com']);
+
+// This works fine
+$user->setAttribute('email', 'newemail@example.com');
+
+// This throws ReadOnlyPropertyException
+$user->setAttribute('id', 2); // Error: Cannot modify readonly property "id"
+
+// This also throws ReadOnlyPropertyException
+unset($user->id); // Error: Cannot unset readonly property "id"
+```
+
+Readonly properties are useful for:
+- Primary keys that shouldn't change after creation
+- Timestamps that are set once
+- Any immutable identifiers or values
 
 ### Extending model construction
 

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -18,7 +18,7 @@ class Config {
 	protected static $invalidArgumentException = InvalidArgumentException::class;
 
 	/**
-	 * @var class-string<Throwable>
+	 * @var class-string<ReadOnlyPropertyException>
 	 */
 	protected static $readOnlyPropertyException = ReadOnlyPropertyException::class;
 
@@ -58,7 +58,7 @@ class Config {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @return class-string<Throwable>
+	 * @return class-string<ReadOnlyPropertyException>
 	 */
 	public static function getReadOnlyPropertyException(): string {
 		return static::$readOnlyPropertyException;
@@ -160,13 +160,14 @@ class Config {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param string $message
+	 * @param ModelProperty $property
+	 * @param string        $message
 	 *
 	 * @return never
-	 * @throws Throwable
+	 * @throws ReadOnlyPropertyException
 	 */
-	public static function throwReadOnlyPropertyException( string $message ): void {
+	public static function throwReadOnlyPropertyException( ModelProperty $property, string $message ): void {
 		$exceptionClass = static::$readOnlyPropertyException;
-		throw new $exceptionClass( $message );
+		throw new $exceptionClass( $property, $message );
 	}
 }

--- a/src/Models/Config.php
+++ b/src/Models/Config.php
@@ -3,6 +3,7 @@
 namespace StellarWP\Models;
 
 use InvalidArgumentException;
+use StellarWP\Models\Exceptions\ReadOnlyPropertyException;
 use Throwable;
 
 class Config {
@@ -15,6 +16,11 @@ class Config {
 	 * @var class-string<Throwable>
 	 */
 	protected static $invalidArgumentException = InvalidArgumentException::class;
+
+	/**
+	 * @var class-string<Throwable>
+	 */
+	protected static $readOnlyPropertyException = ReadOnlyPropertyException::class;
 
 	/**
 	 * Gets the hook prefix.
@@ -48,6 +54,17 @@ class Config {
 	}
 
 	/**
+	 * Gets the ReadOnlyPropertyException class.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return class-string<Throwable>
+	 */
+	public static function getReadOnlyPropertyException(): string {
+		return static::$readOnlyPropertyException;
+	}
+
+	/**
 	 * Resets the class back to default.
 	 *
 	 * @since 1.0.0
@@ -57,6 +74,7 @@ class Config {
 	public static function reset() {
 		static::$hookPrefix = null;
 		static::$invalidArgumentException = InvalidArgumentException::class;
+		static::$readOnlyPropertyException = ReadOnlyPropertyException::class;
 	}
 
 	/**
@@ -106,6 +124,23 @@ class Config {
 	}
 
 	/**
+	 * Allow for overriding the ReadOnlyPropertyException class.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $class
+	 *
+	 * @return void
+	 */
+	public static function setReadOnlyPropertyException( string $class ) {
+		if ( ! is_a( $class, ReadOnlyPropertyException::class, true ) ) {
+			throw new \InvalidArgumentException( 'The provided ReadOnlyPropertyException class must be or must extend ' . ReadOnlyPropertyException::class . '.' );
+		}
+
+		static::$readOnlyPropertyException = $class;
+	}
+
+	/**
 	 * Convenience method for throwing the InvalidArgumentException.
 	 *
 	 * @since 2.0.0
@@ -116,8 +151,22 @@ class Config {
 	 * @throws Throwable
 	 */
 	public static function throwInvalidArgumentException( string $message ): void {
-		/** @var class-string<Throwable> $exceptionClass */
 		$exceptionClass = static::$invalidArgumentException;
+		throw new $exceptionClass( $message );
+	}
+
+	/**
+	 * Convenience method for throwing the ReadOnlyPropertyException.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $message
+	 *
+	 * @return never
+	 * @throws Throwable
+	 */
+	public static function throwReadOnlyPropertyException( string $message ): void {
+		$exceptionClass = static::$readOnlyPropertyException;
 		throw new $exceptionClass( $message );
 	}
 }

--- a/src/Models/Exceptions/ReadOnlyPropertyException.php
+++ b/src/Models/Exceptions/ReadOnlyPropertyException.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace StellarWP\Models\Exceptions;
 
 use RuntimeException;
+use StellarWP\Models\ModelProperty;
+use Throwable;
 
 /**
  * Exception thrown when attempting to modify a readonly property.
@@ -12,4 +14,38 @@ use RuntimeException;
  * @since 2.0.0
  */
 class ReadOnlyPropertyException extends RuntimeException {
+	/**
+	 * The property that caused the exception.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @var ModelProperty
+	 */
+	private $property;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param ModelProperty  $property
+	 * @param string         $message
+	 * @param int            $code
+	 * @param Throwable|null $previous
+	 */
+	public function __construct( ModelProperty $property, string $message = '', int $code = 0, Throwable $previous = null ) {
+		parent::__construct( $message, $code, $previous );
+		$this->property = $property;
+	}
+
+	/**
+	 * Get the property that caused the exception.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return ModelProperty
+	 */
+	public function getProperty(): ModelProperty {
+		return $this->property;
+	}
 }

--- a/src/Models/Exceptions/ReadOnlyPropertyException.php
+++ b/src/Models/Exceptions/ReadOnlyPropertyException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StellarWP\Models\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when attempting to modify a readonly property.
+ *
+ * @since 2.0.0
+ */
+class ReadOnlyPropertyException extends RuntimeException {
+}

--- a/src/Models/ModelProperty.php
+++ b/src/Models/ModelProperty.php
@@ -173,10 +173,17 @@ class ModelProperty {
 	 * @since 2.0.0
 	 *
 	 * @param mixed $value
+	 *
+	 * @throws InvalidArgumentException When the value is invalid.
+	 * @throws \Throwable When attempting to modify a readonly property.
 	 */
 	public function setValue( $value ): self {
+		if ( $this->definition->isReadonly() ) {
+			Config::throwReadOnlyPropertyException( sprintf( 'Cannot modify readonly property "%s".', $this->key ) );
+		}
+
 		if ( ! $this->definition->isValidValue( $value ) ) {
-			throw new \InvalidArgumentException( 'Value is not valid for the property.' );
+			throw new InvalidArgumentException( 'Value is not valid for the property.' );
 		}
 
 		$this->value = $value;
@@ -190,8 +197,14 @@ class ModelProperty {
 	 * Unsets the value of the property.
 	 *
 	 * @since 2.0.0
+	 *
+	 * @throws \Throwable When attempting to unset a readonly property.
 	 */
 	public function unset(): void {
+		if ( $this->definition->isReadonly() ) {
+			Config::throwReadOnlyPropertyException( sprintf( 'Cannot unset readonly property "%s".', $this->key ) );
+		}
+
 		// Mark the value as unset
 		$this->isValueSet = false;
 

--- a/src/Models/ModelProperty.php
+++ b/src/Models/ModelProperty.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace StellarWP\Models;
 
 use InvalidArgumentException;
+use StellarWP\Models\Exceptions\ReadOnlyPropertyException;
 
 class ModelProperty {
 	private const NO_INITIAL_VALUE = '__NO_STELLARWP_MODELS_INITIAL_VALUE__';
@@ -175,11 +176,11 @@ class ModelProperty {
 	 * @param mixed $value
 	 *
 	 * @throws InvalidArgumentException When the value is invalid.
-	 * @throws \Throwable When attempting to modify a readonly property.
+	 * @throws ReadOnlyPropertyException When attempting to modify a readonly property.
 	 */
 	public function setValue( $value ): self {
 		if ( $this->definition->isReadonly() ) {
-			Config::throwReadOnlyPropertyException( sprintf( 'Cannot modify readonly property "%s".', $this->key ) );
+			Config::throwReadOnlyPropertyException( $this, sprintf( 'Cannot modify readonly property "%s".', $this->key ) );
 		}
 
 		if ( ! $this->definition->isValidValue( $value ) ) {
@@ -198,11 +199,11 @@ class ModelProperty {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @throws \Throwable When attempting to unset a readonly property.
+	 * @throws ReadOnlyPropertyException When attempting to unset a readonly property.
 	 */
 	public function unset(): void {
 		if ( $this->definition->isReadonly() ) {
-			Config::throwReadOnlyPropertyException( sprintf( 'Cannot unset readonly property "%s".', $this->key ) );
+			Config::throwReadOnlyPropertyException( $this, sprintf( 'Cannot unset readonly property "%s".', $this->key ) );
 		}
 
 		// Mark the value as unset

--- a/src/Models/ModelPropertyDefinition.php
+++ b/src/Models/ModelPropertyDefinition.php
@@ -69,6 +69,15 @@ class ModelPropertyDefinition {
 	private bool $requiredOnSave = false;
 
 	/**
+	 * Whether the property is readonly.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @var bool
+	 */
+	private bool $readonly = false;
+
+	/**
 	 * The type of the property.
 	 *
 	 * @since 2.0.0
@@ -251,6 +260,15 @@ class ModelPropertyDefinition {
 	}
 
 	/**
+	 * Whether the property is readonly.
+	 *
+	 * @since 2.0.0
+	 */
+	public function isReadonly(): bool {
+		return $this->readonly;
+	}
+
+	/**
 	 * Whether the property is valid for the given value.
 	 *
 	 * @since 2.0.0
@@ -333,6 +351,19 @@ class ModelPropertyDefinition {
 		$this->checkLock();
 
 		$this->requiredOnSave = true;
+
+		return $this;
+	}
+
+	/**
+	 * Makes the property readonly.
+	 *
+	 * @since 2.0.0
+	 */
+	public function readonly(): self {
+		$this->checkLock();
+
+		$this->readonly = true;
 
 		return $this;
 	}

--- a/tests/_support/Helper/BadReadOnlyPropertyException.php
+++ b/tests/_support/Helper/BadReadOnlyPropertyException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace StellarWP\Models\Tests;
+
+use RuntimeException;
+
+class BadReadOnlyPropertyException extends RuntimeException {
+}

--- a/tests/_support/Helper/GoodReadOnlyPropertyException.php
+++ b/tests/_support/Helper/GoodReadOnlyPropertyException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace StellarWP\Models\Tests;
+
+use StellarWP\Models\Exceptions\ReadOnlyPropertyException;
+
+class GoodReadOnlyPropertyException extends ReadOnlyPropertyException {
+}

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -2,8 +2,11 @@
 
 namespace StellarWP\Models;
 
+use StellarWP\Models\Exceptions\ReadOnlyPropertyException;
 use StellarWP\Models\Tests\BadInvalidArgumentException;
+use StellarWP\Models\Tests\BadReadOnlyPropertyException;
 use StellarWP\Models\Tests\GoodInvalidArgumentException;
+use StellarWP\Models\Tests\GoodReadOnlyPropertyException;
 use StellarWP\Models\Tests\ModelsTestCase;
 
 class ConfigTest extends ModelsTestCase {
@@ -35,5 +38,27 @@ class ConfigTest extends ModelsTestCase {
 		}
 
 		$this->assertEquals( \InvalidArgumentException::class, Config::getInvalidArgumentException() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_set_readonly_exception_when_exception_is_valid() {
+		Config::setReadOnlyPropertyException( GoodReadOnlyPropertyException::class );
+
+		$this->assertEquals( GoodReadOnlyPropertyException::class, Config::getReadOnlyPropertyException() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_not_set_readonly_exception_when_exception_is_invalid() {
+		try {
+			Config::setReadOnlyPropertyException( BadReadOnlyPropertyException::class );
+		} catch ( \Exception $e ) {
+			$this->assertEquals( \InvalidArgumentException::class, get_class( $e ) );
+		}
+
+		$this->assertEquals( ReadOnlyPropertyException::class, Config::getReadOnlyPropertyException() );
 	}
 }

--- a/tests/wpunit/ModelPropertyDefinitionTest.php
+++ b/tests/wpunit/ModelPropertyDefinitionTest.php
@@ -112,6 +112,21 @@ class ModelPropertyDefinitionTest extends ModelsTestCase {
 	/**
 	 * @since 2.0.0
 	 *
+	 * @covers ::readonly
+	 * @covers ::isReadonly
+	 */
+	public function testReadonlyAndIsReadonly() {
+		$definition = new ModelPropertyDefinition();
+
+		$this->assertFalse($definition->isReadonly());
+
+		$definition->readonly();
+		$this->assertTrue($definition->isReadonly());
+	}
+
+	/**
+	 * @since 2.0.0
+	 *
 	 * @covers ::lock
 	 * @covers ::isLocked
 	 * @covers ::checkLock

--- a/tests/wpunit/ModelPropertyTest.php
+++ b/tests/wpunit/ModelPropertyTest.php
@@ -2,6 +2,7 @@
 
 namespace StellarWP\Models\Tests\Unit;
 
+use StellarWP\Models\Exceptions\ReadOnlyPropertyException;
 use StellarWP\Models\ModelProperty;
 use StellarWP\Models\ModelPropertyDefinition;
 use StellarWP\Models\Tests\ModelsTestCase;
@@ -268,5 +269,56 @@ class ModelPropertyTest extends ModelsTestCase {
 
 		// Should no longer be dirty because original value was not set
 		$this->assertFalse($property->isDirty());
+	}
+
+	/**
+	 * @since 2.0.0
+	 *
+	 * @covers ::__construct
+	 * @covers ::setValue
+	 */
+	public function testReadonlyPropertyCanBeSetInConstructor() {
+		$definition = new ModelPropertyDefinition();
+		$definition->type('string')->readonly();
+
+		// Should be able to set readonly property in constructor
+		$property = new ModelProperty('id', $definition, 'initial-value');
+
+		$this->assertSame('initial-value', $property->getValue());
+		$this->assertTrue($property->isSet());
+	}
+
+	/**
+	 * @since 2.0.0
+	 *
+	 * @covers ::setValue
+	 */
+	public function testReadonlyPropertyCannotBeModified() {
+		$definition = new ModelPropertyDefinition();
+		$definition->type('string')->readonly();
+
+		$property = new ModelProperty('id', $definition, 'initial-value');
+
+		$this->expectException(ReadOnlyPropertyException::class);
+		$this->expectExceptionMessage('Cannot modify readonly property "id".');
+
+		$property->setValue('new-value');
+	}
+
+	/**
+	 * @since 2.0.0
+	 *
+	 * @covers ::unset
+	 */
+	public function testReadonlyPropertyCannotBeUnset() {
+		$definition = new ModelPropertyDefinition();
+		$definition->type('string')->readonly();
+
+		$property = new ModelProperty('id', $definition, 'initial-value');
+
+		$this->expectException(ReadOnlyPropertyException::class);
+		$this->expectExceptionMessage('Cannot unset readonly property "id".');
+
+		$property->unset();
 	}
 }

--- a/tests/wpunit/ModelPropertyTest.php
+++ b/tests/wpunit/ModelPropertyTest.php
@@ -321,4 +321,24 @@ class ModelPropertyTest extends ModelsTestCase {
 
 		$property->unset();
 	}
+
+	/**
+	 * @since 2.0.0
+	 *
+	 * @covers ::setValue
+	 */
+	public function testReadonlyExceptionContainsProperty() {
+		$definition = new ModelPropertyDefinition();
+		$definition->type('string')->readonly();
+
+		$property = new ModelProperty('id', $definition, 'initial-value');
+
+		try {
+			$property->setValue('new-value');
+			$this->fail('Expected ReadOnlyPropertyException to be thrown');
+		} catch (ReadOnlyPropertyException $e) {
+			$this->assertInstanceOf(ModelProperty::class, $e->getProperty());
+			$this->assertSame('id', $e->getProperty()->getKey());
+		}
+	}
 }


### PR DESCRIPTION
This adds support for PHP 8.1 similar read-only properties. A property can be set as readonly within the definition, which means:

1. It can only be set within the initial model constructor or to whatever the default value is
2. It cannot be unset
3. Trying to modify it subsequently results in a `ReadOnlyPropertyException`

A key difference to true PHP 8.1 readonly properties is that 8.1 properties _can_ be set _internally_ if the constructor doesn't set an initial value, but only once. It's honestly kind of weird that it can work that way. To pull this off would mean doing more work to differentiate between internally and externally setting properties, so I figured I'd just wait on that until a true use-case came along.