### PR TITLE
Changes how model properties are checked to be set

### DIFF
--- a/tests/wpunit/ModelPropertyTest.php
+++ b/tests/wpunit/ModelPropertyTest.php
@@ -187,6 +187,39 @@ class ModelPropertyTest extends ModelsTestCase {
 	/**
 	 * @since 2.0.0
 	 *
+	 * @covers ::isSet
+	 */
+	public function testIsSet() {
+		$definition = new ModelPropertyDefinition();
+
+		// Test with initial value
+		$property = new ModelProperty('name', $definition, 'John');
+		$this->assertTrue($property->isSet());
+
+		// Test with no initial value
+		$property = new ModelProperty('name', $definition);
+		$this->assertFalse($property->isSet());
+
+		// Test with default value
+		$definition = (new ModelPropertyDefinition())->default('default-value');
+		$property = new ModelProperty('name', $definition);
+		$this->assertTrue($property->isSet());
+
+		// Test with null value
+		$definition = (new ModelPropertyDefinition())->nullable();
+		$property = new ModelProperty('name', $definition);
+		$this->assertFalse($property->isSet());
+		$property->setValue(null);
+		$this->assertTrue($property->isSet());
+
+		// Test that a null initial value is also considered set
+		$property = new ModelProperty('name', $definition, null);
+		$this->assertTrue($property->isSet());
+	}
+
+	/**
+	 * @since 2.0.0
+	 *
 	 * @covers ::unset
 	 * @covers ::isSet
 	 */


### PR DESCRIPTION
I found a nuanced situation in how the `ModelProperty` class determines whether a property is set or not. This ends up bumping into how PHP itself determines whether properties exist and are set on its own objects.

Consider this unit test code:
```php
$definition = (new ModelPropertyDefinition())->nullable();
$property = new ModelProperty('name', $definition);

$property->setValue(null);
$this->assertTrue($property->isSet());
```

We create a property that is nullable, then we explicitly set that value to null. So, is that property set or not?

### Option 1: Follow PHP `isset()`

If we follow PHP `isset()` rules, then no, it's not, because null is considered a special value in this case that means something is not set — it is a "nothing" value. Consider this:

```php
$obj = new stdClass;
isset($obj->foo); // false

$obj->foo = null;
isset($obj->foo); // still false
```

So to align with this means that null is considered a special "nothing" value indicating a property is not set.

### Option 2: Follow strict assignment

This PR goes this route. In this case, we're functioning more like PHP's `property_exists()` function. That is, until a value is explicitly set it is false, but once it is defined then it's true, regardless of whether it's false or not.

Now, you'll notice in this PR I'm not using `property_exists()`, and that's because it always returns true for a property defined as part of a class, even when that property has no initial value. For this reason, I'm using distinct internal flags for tracking whether the value has been set or not.

### Other considerations

If you look at the `ModelProperty::__construct` (not modified in this PR), you'll notice a special `ModelProperty::NO_INITIAL_VALUE` is used. This was in light of this concept to differentiate between whether the property was given an initial value, versus it _was_ given an initial value that is null.

This also touches on the idea of dirty/clean values and committing/reverting said changes, as you'll see in the PR changes. The two concepts are connected but not quiet the same.