### PR TITLE
Feature: adds model definition generation overloading

### DIFF
--- a/src/Models/ModelPropertyDefinition.php
+++ b/src/Models/ModelPropertyDefinition.php
@@ -122,8 +122,6 @@ class ModelPropertyDefinition {
 	 * @throws RuntimeException When no cast method is set.
 	 */
 	public function cast( $value ) {
-		$this->checkLock();
-
 		if ( ! $this->canCast() ) {
 			throw new RuntimeException( 'No cast method set' );
 		}


### PR DESCRIPTION
This separates the logic for how property definitions are generated from the caching logic. This makes it possible to overload the generation method, giving model subclasses the ability to add additional definitions or have a completely unique way of generating the definitions.

What's important to note here is that it's done in this way and time because the property collection is subsequently created from the definitions, and this method keeps those in sync — which is really important.

I also snuck in a fix that was causing the `PropertyDefinition::cast()` method to fail when creating a model from data because it was checking if the definition was locked... which is weird. The definition lock is to prevent the definition from changing, but using it to cast doesn't modify it at all and should always be callable.